### PR TITLE
Configure infrastructure and release process

### DIFF
--- a/.github/actions/kubectl-helm/Dockerfile
+++ b/.github/actions/kubectl-helm/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:latest as builder
+ARG KUBE_VERSION=1.18.2
+ARG HELM_VERSION=3.2.0
+ARG OS_TYPE=linux
+ARG ARCH=amd64
+WORKDIR /opt/app
+RUN apk --no-cache add curl \
+  && curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/${OS_TYPE}/${ARCH}/kubectl \
+  && chmod +x ./kubectl \
+  && curl -LO https://get.helm.sh/helm-v${HELM_VERSION}-${OS_TYPE}-${ARCH}.tar.gz \
+  && tar -zxvf helm* \
+  && mv ${OS_TYPE}-${ARCH}/* ./ \
+  && ./kubectl version --client \
+  && ./helm version --client
+
+FROM alpine:latest
+ENV KUBECONFIG=/opt/kubeconfig
+COPY --from=builder /opt/app/kubectl /usr/local/bin
+COPY --from=builder /opt/app/helm /usr/local/bin
+COPY entrypoint.sh .
+RUN apk add --no-cache bash curl gettext git jq openssh \
+  && chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.github/actions/kubectl-helm/action.yml
+++ b/.github/actions/kubectl-helm/action.yml
@@ -1,0 +1,11 @@
+name: Kubectl Helm
+description: Provides the Kubectl and Helm binaries
+inputs:
+  cmd:
+    description: Command to run in the image
+    required: true
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ inputs.cmd }}

--- a/.github/actions/kubectl-helm/entrypoint.sh
+++ b/.github/actions/kubectl-helm/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+result="$(bash -c "$1")"
+
+status=$?
+echo ::set-output name=result::$result
+echo "$result"
+if [[ $status -eq 0 ]]; then exit 0; else exit 1; fi

--- a/.github/workflows/infra-common.yml
+++ b/.github/workflows/infra-common.yml
@@ -1,0 +1,74 @@
+name: Common Infrastructure
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - infrastructure/common/**/*
+      - infrastructure/modules/**/*
+
+defaults:
+  run:
+    working-directory: infrastructure/common
+
+env:
+  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+  TF_CLI_ARGS: -no-color
+  TF_INPUT: false
+  TF_IN_AUTOMATION: 1
+  TF_VAR_github_token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+  WORKSPACE: default
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: |
+            {
+              "clientId": "${{ secrets.ARM_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.ARM_CLIENT_SECRET }}",
+              "subscriptionId": "${{ secrets.ARM_SUBSCRIPTION_ID }}",
+              "tenantId": "${{ secrets.ARM_TENANT_ID }}"
+            }
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.13.4
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        run: |
+          terraform init
+          terraform workspace new "${{ env.WORKSPACE }}" || true
+          terraform workspace select "${{ env.WORKSPACE }}"
+
+      - run: terraform plan -out tfplan
+
+      - name: Unlock resources
+        run: bash ../scripts/lockResourceGroups.sh
+          unlock
+          "$(terraform workspace show)"
+          "$(terraform output app-name)"
+
+      - run: terraform apply tfplan
+
+      - name: Lock resources
+        if: ${{ always() }}
+        run: bash ../scripts/lockResourceGroups.sh
+          lock
+          "$(terraform workspace show)"
+          "$(terraform output app-name)"

--- a/.github/workflows/infra-environments.yml
+++ b/.github/workflows/infra-environments.yml
@@ -1,0 +1,138 @@
+name: Environment Infrastructure
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - infrastructure/environments/**/*
+      - infrastructure/k8s/**/*
+      - infrastructure/modules/**/*
+      - environments/**/*
+
+defaults:
+  run:
+    working-directory: infrastructure/environments
+
+env:
+  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  KUBECONFIG: ./kubeconfig
+  TERRAFORM_COMMON_WORKSPACE: default
+  TF_CLI_ARGS: -no-color
+  TF_INPUT: false
+  TF_IN_AUTOMATION: 1
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        environment:
+          - dev
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: |
+            {
+              "clientId": "${{ secrets.ARM_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.ARM_CLIENT_SECRET }}",
+              "subscriptionId": "${{ secrets.ARM_SUBSCRIPTION_ID }}",
+              "tenantId": "${{ secrets.ARM_TENANT_ID }}"
+            }
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.13.4
+          terraform_wrapper: false
+
+      - name: Get Terraform Common config
+        id: tf_common
+        working-directory: infrastructure/common
+        run: |
+          terraform init
+          terraform workspace select "$TERRAFORM_COMMON_WORKSPACE"
+
+          echo "::set-output name=container_registry_name::$(terraform output containers_name)"
+          echo "::set-output name=containers_server::$(terraform output containers_server)"
+          echo "::set-output name=container_registry_rg_name::$(terraform output containers_rg_name)"
+          echo "::set-output name=containers_username::$(terraform output containers_username)"
+          echo "::set-output name=containers_password::$(terraform output containers_password)"
+          echo "::set-output name=key_vault_id::$(terraform output key_vault_id)"
+
+      - name: "Terraform environment: ${{ matrix.environment }}"
+        run: echo ${{ matrix.environment }}
+
+      - name: Terraform Init
+        run: |
+          terraform init
+          terraform workspace new "${{ matrix.environment }}" || true
+          terraform workspace select "${{ matrix.environment }}"
+
+      - name: Get Terraform variables
+        id: vars
+        run: |
+          VARS_FILE="../../environments/${{ matrix.environment }}.tfvars"
+
+          # Don't fail if file doesn't exist
+          touch ${VARS_FILE}
+
+          # Output variables
+          cat ${VARS_FILE}
+
+          echo "::set-output name=tfvars::$VARS_FILE"
+
+      - name: Terraform Plan
+        run: terraform plan
+          -var container_registry_name="${{ steps.tf_common.outputs.container_registry_name }}"
+          -var container_registry_rg_name="${{ steps.tf_common.outputs.container_registry_rg_name }}"
+          -var key_vault_id="${{ steps.tf_common.outputs.key_vault_id }}"
+          -var-file="${{ steps.vars.outputs.tfvars }}"
+          -out tfplan
+
+      - name: Unlock resources
+        run: bash ../scripts/lockResourceGroups.sh
+          unlock
+          "$(terraform workspace show)"
+          "$(terraform output app-name)"
+
+      - name: Terraform Apply
+        run: terraform apply tfplan
+
+      - name: Lock resources
+        if: ${{ always() }}
+        run: bash ../scripts/lockResourceGroups.sh
+          lock
+          "$(terraform workspace show)"
+          "$(terraform output app-name)"
+
+      - name: Get Kubeconfig
+        run: terraform output kubeconfig > ../../$KUBECONFIG
+
+      - name: Configure Kubernetes instance
+        uses: ./.github/actions/kubectl-helm
+        env:
+          CERT_MANAGER_VERSION: 1.0.3
+          CLUSTER: ${{ matrix.environment }}
+          DEFAULT_BRANCH: master
+          DEPLOY_NAMESPACE: app-${{ matrix.environment }}
+          DOCKER_PASSWORD: ${{ steps.tf_common.outputs.containers_password }}
+          DOCKER_SERVER: ${{ steps.tf_common.outputs.containers_server }}
+          DOCKER_USERNAME: ${{ steps.tf_common.outputs.containers_username }}
+          EMAIL_ADDRESS: ${{ secrets.DEVOPS_EMAIL_ADDRESS }}
+          REPO_API_URL: https://api.github.com
+          REPO_DOMAIN: github.com
+          REPO_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          REPO_URL: ${{ github.repository }}
+        with:
+          cmd: bash ./infrastructure/k8s/setup.sh

--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,6 @@ Thumbs.db
 .vscode
 
 .envrc*
-
+tmp
+.kubeconfig
+known_hosts

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ crash.log
 # to change depending on the environment.
 #
 *.tfvars
+!/environments/*.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
@@ -30,6 +31,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+tfplan
 
 # Ignore CLI configuration files
 .terraformrc

--- a/README.md
+++ b/README.md
@@ -77,3 +77,12 @@ To stop all services:
 ```
 docker-compose down
 ```
+
+# Releases
+
+Releases are done using the GitOps workflow. Lots can be found about [GitOps
+online](https://www.gitops.tech/), but in summary, we have a release manifest
+(in `/releases`) which describes the [Helm charts](https://helm.sh/) (in 
+`/charts/app`). The release manifest has a few variables, but the important
+ones are the image and the tag to track, the URL of the Docker registry and any
+variables which we want to apply (in this instance, just the URL).

--- a/charts/app/.helmignore
+++ b/charts/app/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: app
+description: PINS Appeal Process
+type: application
+version: 0.1.0
+icon: https://github.com/planning-inspectorate.png

--- a/charts/app/templates/NOTES.txt
+++ b/charts/app/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+  http://{{ .Values.ingress.host }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "app.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "app.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "app.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "app.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "app.labels" -}}
+helm.sh/chart: {{ include "app.chart" . }}
+{{ include "app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/app/templates/formsWebApp.yaml
+++ b/charts/app/templates/formsWebApp.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}-form-web-app
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.formsWebApp.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.formsWebApp.image.repository }}:{{ .Values.formsWebApp.image.tag }}"
+          imagePullPolicy: {{ .Values.formsWebApp.image.pullPolicy }}
+          ports:
+            - name: forms-web-app
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: forms-web-app
+          readinessProbe:
+            httpGet:
+              path: /
+              port: forms-web-app
+          env:
+            - name: PORT
+              value: {{ 3000 | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/app/templates/hpa.yaml
+++ b/charts/app/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "app.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "app.fullname" . -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.ingress.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | quote }}
+  {{- end }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.secretName }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ .Values.formsWebApp.service.port }}
+{{- end }}

--- a/charts/app/templates/service.yaml
+++ b/charts/app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.formsWebApp.service.port }}
+      targetPort: forms-web-app
+      protocol: TCP
+      name: form-web-app
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/charts/app/templates/serviceaccount.yaml
+++ b/charts/app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/app/templates/tests/test-connection.yaml
+++ b/charts/app/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "app.fullname" . }}-test-connection"
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "app.fullname" . }}:{{ .Values.formsWebApp.service.port }}']
+  restartPolicy: Never

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -1,0 +1,76 @@
+# Default values for app.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+formsWebApp:
+  replicaCount: 2
+  service:
+    port: 9000
+  image:
+    repository: pinscommonukscontainersdefault.azurecr.io/forms-web-app
+    pullPolicy: Always
+    tag: latest
+
+imagePullSecrets:
+  - name: azure-docker-registry
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  host: chart.example.com
+  secretName: ingress-tls-secret
+  clusterIssuer: letsencrypt
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/environments/README.md
+++ b/environments/README.md
@@ -1,0 +1,22 @@
+# Environments
+
+These describe the environments that exist in the Azure infrastructure
+
+## Terraform Variable Files
+
+> New environments will need to be added to the `jobs.provision.strategy.matrix` 
+> in the `.github/workflows/infra-environments.yml` file.
+
+These are Terraform variable files (`<environment>.tfvars`) that work with the
+environment infrastructure in `/infrastructure/environments`. These are designed
+to represent one environment per file - nominally, we're expecting to have 
+`dev.tfvars`, `staging.tfvars` and `prod.tfvars` but there are no constraints on 
+naming convention.
+
+Variables in these files should be defined as key/value pairs, eg:
+```hcl
+location = "eastus"
+```
+
+> **NB** JSON is not (currently) supported for variables files - this can be
+> added if required.

--- a/infrastructure/common/README.md
+++ b/infrastructure/common/README.md
@@ -38,3 +38,4 @@ Infrastructure which is common to the subscription, regardless of which environm
 | containers\_rg\_name | Resource group name for the container registry |
 | containers\_server | Server URL for the container registry |
 | containers\_username | Username for the container registry |
+| key\_vault\_id | ID of the key vault |

--- a/infrastructure/common/README.md
+++ b/infrastructure/common/README.md
@@ -1,0 +1,40 @@
+# Common Infrastructure
+
+Infrastructure which is common to the subscription, regardless of which environment
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| azurerm | ~> 2.31.1 |
+| github | ~> 2.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| azurerm | ~> 2.31.1 |
+| github | ~> 2.9 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| container\_sku\_type | SKU for registry - 'Basic' (10GB), 'Standard' (100GB) or 'Premium' (500GB) | `string` | `"Standard"` | no |
+| github\_org\_name | Name of the GitHub organisation | `string` | `"foundry4"` | no |
+| github\_repo\_name | Name of the GitHub repository | `string` | `"appeal-planning-decision"` | no |
+| github\_token | Token to access the GitHub API | `string` | n/a | yes |
+| location | Default location for resources | `string` | `"uksouth"` | no |
+| prefix | Resource prefix | `string` | `"pinscommon"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| app-name | The application name - used for identifying resource groups |
+| containers\_location | Location of the container registry |
+| containers\_name | Name of the container registry |
+| containers\_password | Password for the container registry |
+| containers\_rg\_name | Resource group name for the container registry |
+| containers\_server | Server URL for the container registry |
+| containers\_username | Username for the container registry |

--- a/infrastructure/common/containers.tf
+++ b/infrastructure/common/containers.tf
@@ -1,0 +1,18 @@
+resource "azurerm_resource_group" "containers" {
+  location = var.location
+  name = format(local.name_format, "containers")
+
+  tags = {
+    app = local.app_name
+    env = terraform.workspace
+    lock = local.lock_delete
+  }
+}
+
+resource "azurerm_container_registry" "containers" {
+  location = azurerm_resource_group.containers.location
+  name = replace(format(local.name_format, "containers"), "-", "")
+  resource_group_name = azurerm_resource_group.containers.name
+  admin_enabled = true
+  sku = var.container_sku_type
+}

--- a/infrastructure/common/github.tf
+++ b/infrastructure/common/github.tf
@@ -1,0 +1,17 @@
+resource "github_actions_secret" "docker_password" {
+  plaintext_value = azurerm_container_registry.containers.admin_password
+  repository = var.github_repo_name
+  secret_name = "DOCKER_PASSWORD"
+}
+
+resource "github_actions_secret" "docker_registry" {
+  plaintext_value = azurerm_container_registry.containers.login_server
+  repository = var.github_repo_name
+  secret_name = "DOCKER_REGISTRY"
+}
+
+resource "github_actions_secret" "docker_username" {
+  plaintext_value = azurerm_container_registry.containers.admin_username
+  repository = var.github_repo_name
+  secret_name = "DOCKER_USERNAME"
+}

--- a/infrastructure/common/key_vault.tf
+++ b/infrastructure/common/key_vault.tf
@@ -1,0 +1,42 @@
+resource "azurerm_resource_group" "key_vault" {
+  location = var.location
+  name = format(local.name_format, "vault")
+
+  tags = {
+    app = local.app_name
+    env = terraform.workspace
+    lock = local.lock_delete
+  }
+}
+
+resource "azurerm_key_vault" "key_vault" {
+  location = azurerm_resource_group.containers.location
+  name = substr(format(local.name_format, "vault"), 0, 24)
+  resource_group_name = azurerm_resource_group.key_vault.name
+  sku_name = "standard"
+  enabled_for_disk_encryption = true
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  soft_delete_enabled = true
+  soft_delete_retention_days  = 7
+  purge_protection_enabled = false
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = [
+      "backup",
+      "delete",
+      "get",
+      "list",
+      "recover",
+      "restore",
+      "set"
+    ]
+  }
+
+  network_acls {
+    default_action = "Deny"
+    bypass = "AzureServices"
+  }
+}

--- a/infrastructure/common/local.tf
+++ b/infrastructure/common/local.tf
@@ -1,0 +1,13 @@
+locals {
+  app_name = "pins-common"
+  location = substr(var.location, 0, 3)
+  lock_delete = "CanNotDelete"
+  lock_none = null # Doesn't add tag
+  lock_readonly = "ReadOnly"
+  name_format = join("-", [
+    var.prefix,
+    local.location,
+    "%s", # name
+    replace(terraform.workspace, "/[\\W\\-]/", "") # alphanumeric workspace name
+  ])
+}

--- a/infrastructure/common/main.tf
+++ b/infrastructure/common/main.tf
@@ -17,3 +17,5 @@ provider "github" {
   organization = var.github_org_name
   token = var.github_token
 }
+
+data "azurerm_client_config" "current" {}

--- a/infrastructure/common/main.tf
+++ b/infrastructure/common/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name = "pins-uk-terraform-rg"
+    storage_account_name = "pinsf4terraform"
+    container_name = "tfstate"
+    key = "common.tfstate"
+  }
+}
+
+provider "azurerm" {
+  version = "~> 2.31.1"
+  features {}
+}
+
+provider "github" {
+  version = "~> 2.9"
+  organization = var.github_org_name
+  token = var.github_token
+}

--- a/infrastructure/common/output.tf
+++ b/infrastructure/common/output.tf
@@ -41,3 +41,12 @@ output "containers_username" {
   description = "Username for the container registry"
   value = azurerm_container_registry.containers.admin_username
 }
+
+/*
+  Key Vault
+ */
+
+output "key_vault_id" {
+  description = "ID of the key vault"
+  value = azurerm_key_vault.key_vault.id
+}

--- a/infrastructure/common/output.tf
+++ b/infrastructure/common/output.tf
@@ -1,0 +1,43 @@
+/*
+  Misc
+ */
+
+output "app-name" {
+  description = "The application name - used for identifying resource groups"
+  value = local.app_name
+}
+
+/*
+  Containers
+ */
+
+output "containers_location" {
+  description = "Location of the container registry"
+  value = azurerm_resource_group.containers.location
+}
+
+output "containers_name" {
+  description = "Name of the container registry"
+  value = azurerm_container_registry.containers.name
+}
+
+output "containers_password" {
+  description = "Password for the container registry"
+  sensitive = true
+  value = azurerm_container_registry.containers.admin_password
+}
+
+output "containers_rg_name" {
+  description = "Resource group name for the container registry"
+  value = azurerm_resource_group.containers.name
+}
+
+output "containers_server" {
+  description = "Server URL for the container registry"
+  value = azurerm_container_registry.containers.login_server
+}
+
+output "containers_username" {
+  description = "Username for the container registry"
+  value = azurerm_container_registry.containers.admin_username
+}

--- a/infrastructure/common/variables.tf
+++ b/infrastructure/common/variables.tf
@@ -1,0 +1,46 @@
+/*
+  Common
+ */
+
+variable "location" {
+  description = "Default location for resources"
+  default = "uksouth"
+  type = string
+}
+
+variable "prefix" {
+  description = "Resource prefix"
+  default = "pinscommon"
+  type = string
+}
+
+/*
+  Container
+ */
+
+variable "container_sku_type" {
+  description = "SKU for registry - 'Basic' (10GB), 'Standard' (100GB) or 'Premium' (500GB)"
+  default = "Standard"
+  type = string
+}
+
+/*
+  GitHub
+ */
+
+variable "github_token" {
+  description = "Token to access the GitHub API"
+  type = string
+}
+
+variable "github_org_name" {
+  description = "Name of the GitHub organisation"
+  default = "foundry4"
+  type = string
+}
+
+variable "github_repo_name" {
+  description = "Name of the GitHub repository"
+  default = "appeal-planning-decision"
+  type = string
+}

--- a/infrastructure/environments/README.md
+++ b/infrastructure/environments/README.md
@@ -1,3 +1,48 @@
 # Environments
 
 Infrastructure which the applications are deployed toInfrastructure which is common to the su
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| azurerm | ~> 2.31.1 |
+| random | ~> 3.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| azurerm | ~> 2.31.1 |
+| random | ~> 3.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| container\_registry\_name | Name of the container registry | `string` | n/a | yes |
+| container\_registry\_rg\_name | Name of the registry's resource group | `string` | n/a | yes |
+| k8s\_availability\_zones | Zones to run the node pools in | `list(string)` | `null` | no |
+| k8s\_max\_nodes | Maximum number of nodes per pool | `number` | `3` | no |
+| k8s\_min\_nodes | Minimum number of nodes per pool | `number` | `1` | no |
+| k8s\_rbac\_admin\_groups | List of AAD groups that have admin rights on the cluster | `set(string)` | `[]` | no |
+| k8s\_rbac\_enabled | Enable RBAC on cluster | `bool` | `true` | no |
+| k8s\_version\_prefix | Version prefix to use - ensure you end with dot (.) | `string` | `"1.18."` | no |
+| k8s\_vm\_size | VM size | `string` | `"Standard_DS2_v2"` | no |
+| key\_vault\_id | Key Vault ID | `string` | n/a | yes |
+| location | Default location for resources | `string` | `"uksouth"` | no |
+| mongodb\_failover\_read\_locations | Locations where read failover replicas are created for MongoDB | `list(string)` | `[]` | no |
+| mongodb\_max\_throughput | Max throughput of the MongoDB database - set in increments of 1,000 between 4,000 and 1,000,000 | `number` | `4000` | no |
+| prefix | Resource prefix | `string` | `"pins"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| app-name | The application name - used for identifying resource groups |
+| containers\_password | Password for the container registry |
+| containers\_server | Server URL for the container registry |
+| containers\_username | Username for the container registry |
+| kube\_load\_balancer\_ip | The IP of the load balancer for the Kubernetes cluster |
+| kube\_load\_balancer\_rg | The rosource group the load balancer IP exists in |
+| kubeconfig | The Kubernetes config file |

--- a/infrastructure/environments/README.md
+++ b/infrastructure/environments/README.md
@@ -1,0 +1,3 @@
+# Environments
+
+Infrastructure which the applications are deployed toInfrastructure which is common to the su

--- a/infrastructure/environments/kubernetes.tf
+++ b/infrastructure/environments/kubernetes.tf
@@ -1,0 +1,110 @@
+resource "azurerm_resource_group" "k8s" {
+  location = var.location
+  name = format(local.name_format, "k8s")
+
+  tags = {
+    app = local.app_name
+    env = terraform.workspace
+    lock = local.lock_delete
+  }
+}
+
+resource "random_integer" "k8s" {
+  max = 9999
+  min = 1000
+}
+
+resource "azurerm_log_analytics_workspace" "k8s" {
+  name = format(local.name_format, "kubernetes-${random_integer.k8s.result}")
+  location = azurerm_resource_group.k8s.location
+  resource_group_name = azurerm_resource_group.k8s.name
+  sku = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "k8s" {
+  solution_name = "ContainerInsights"
+  location = azurerm_resource_group.k8s.location
+  resource_group_name = azurerm_resource_group.k8s.name
+  workspace_name = azurerm_log_analytics_workspace.k8s.name
+  workspace_resource_id = azurerm_log_analytics_workspace.k8s.id
+
+  plan {
+    publisher = "Microsoft"
+    product = "OMSGallery/ContainerInsights"
+  }
+}
+
+data "azurerm_kubernetes_service_versions" "k8s" {
+  location = azurerm_resource_group.k8s.location
+  include_preview = false
+  version_prefix = var.k8s_version_prefix
+}
+
+resource "azurerm_kubernetes_cluster" "k8s" {
+  name = format(local.name_format, "k8s")
+  location = azurerm_resource_group.k8s.location
+  resource_group_name = azurerm_resource_group.k8s.name
+  dns_prefix = "${var.prefix}-${terraform.workspace}"
+
+  kubernetes_version = data.azurerm_kubernetes_service_versions.k8s.latest_version
+
+  default_node_pool {
+    name = "default"
+    vm_size = var.k8s_vm_size
+    availability_zones = var.k8s_availability_zones
+
+    enable_auto_scaling = true
+    min_count = var.k8s_min_nodes
+    max_count = var.k8s_max_nodes
+    orchestrator_version = data.azurerm_kubernetes_service_versions.k8s.latest_version
+    type = "VirtualMachineScaleSets"
+  }
+
+  role_based_access_control {
+    enabled = var.k8s_rbac_enabled
+//    azure_active_directory {
+//      tenant_id = data.azurerm_client_config.current.tenant_id
+//      managed = true
+//      admin_group_object_ids = var.k8s_rbac_admin_groups
+//    }
+  }
+
+  network_profile {
+    network_plugin = "kubenet"
+    load_balancer_sku = "Standard"
+  }
+
+  addon_profile {
+    kube_dashboard {
+      enabled = false
+    }
+
+    oms_agent {
+      enabled = true
+      log_analytics_workspace_id = azurerm_log_analytics_workspace.k8s.id
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "k8s" {
+  key_vault_id = var.key_vault_id
+  object_id = azurerm_kubernetes_cluster.k8s.identity.0.principal_id
+  tenant_id = azurerm_kubernetes_cluster.k8s.identity.0.tenant_id
+
+  secret_permissions = [
+    "get"
+  ]
+}
+
+resource "azurerm_public_ip" "k8s" {
+  name = format(local.name_format, "k8s")
+  location = azurerm_resource_group.k8s.location
+  resource_group_name = azurerm_resource_group.k8s.name
+  allocation_method = "Static"
+  sku = "Standard"
+  domain_name_label = "${var.prefix}-${terraform.workspace}"
+}

--- a/infrastructure/environments/local.tf
+++ b/infrastructure/environments/local.tf
@@ -1,0 +1,19 @@
+locals {
+  app_name = "pins-env"
+  location = substr(var.location, 0, 3) # short version of the location
+  lock_delete = "CanNotDelete"
+  lock_none = null # Doesn't add tag
+  lock_readonly = "ReadOnly"
+  name_format = join("-", [
+    var.prefix,
+    local.location,
+    "%s", # name
+    replace(terraform.workspace, "/[\\W\\-]/", "") # alphanumeric workspace name
+  ])
+  web_app_subdomain = terraform.workspace == "prod" ? "app" : "${terraform.workspace}-app"
+  web_app_url_format = join("-", [
+    var.prefix,
+    "%s", # name
+    local.web_app_subdomain
+  ])
+}

--- a/infrastructure/environments/main.tf
+++ b/infrastructure/environments/main.tf
@@ -12,6 +12,10 @@ provider "azurerm" {
   features {}
 }
 
+provider "random" {
+  version = "~> 3.0.0"
+}
+
 data "azurerm_client_config" "current" {}
 
 data "azurerm_container_registry" "pins" {

--- a/infrastructure/environments/main.tf
+++ b/infrastructure/environments/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name = "pins-uk-terraform-rg"
+    storage_account_name = "pinsf4terraform"
+    container_name = "tfstate"
+    key = "environments.tfstate"
+  }
+}
+
+provider "azurerm" {
+  version = "~> 2.31.1"
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azurerm_container_registry" "pins" {
+  name = var.container_registry_name
+  resource_group_name = var.container_registry_rg_name
+}

--- a/infrastructure/environments/output.tf
+++ b/infrastructure/environments/output.tf
@@ -6,3 +6,43 @@ output "app-name" {
   description = "The application name - used for identifying resource groups"
   value = local.app_name
 }
+
+/*
+  Containers
+ */
+
+output "containers_password" {
+  description = "Password for the container registry"
+  sensitive = true
+  value = data.azurerm_container_registry.pins.admin_password
+}
+
+output "containers_server" {
+  description = "Server URL for the container registry"
+  value = data.azurerm_container_registry.pins.login_server
+}
+
+output "containers_username" {
+  description = "Username for the container registry"
+  value = data.azurerm_container_registry.pins.admin_username
+}
+
+/*
+  Kubernetes
+ */
+
+output "kubeconfig" {
+  description = "The Kubernetes config file"
+  sensitive = true
+  value = try(azurerm_kubernetes_cluster.k8s.kube_config_raw, null)
+}
+
+output "kube_load_balancer_ip" {
+  description = "The IP of the load balancer for the Kubernetes cluster"
+  value = try(azurerm_public_ip.k8s.ip_address, null)
+}
+
+output "kube_load_balancer_rg" {
+  description = "The rosource group the load balancer IP exists in"
+  value = try(azurerm_resource_group.k8s.name, null)
+}

--- a/infrastructure/environments/output.tf
+++ b/infrastructure/environments/output.tf
@@ -1,0 +1,8 @@
+/*
+  Misc
+ */
+
+output "app-name" {
+  description = "The application name - used for identifying resource groups"
+  value = local.app_name
+}

--- a/infrastructure/environments/variables.tf
+++ b/infrastructure/environments/variables.tf
@@ -1,0 +1,49 @@
+/*
+  Common
+ */
+
+variable "location" {
+  description = "Default location for resources"
+  default = "uksouth"
+  type = string
+}
+
+variable "prefix" {
+  description = "Resource prefix"
+  default = "pins"
+  type = string
+}
+
+/*
+  Container Registry
+ */
+
+variable "container_registry_name" {
+  description = "Name of the container registry"
+  default = "pinscommonukscontainersprod"
+  type = string
+}
+
+variable "container_registry_rg_name" {
+  description = "Name of the registry's resource group"
+  default = "pinscommon-uks-containers-prod"
+  type = string
+}
+
+/*
+  MongoDB defaults
+
+  These are used as base settings
+ */
+
+variable "mongodb_failover_read_locations" {
+  description = "Locations where read failover replicas are created for MongoDB"
+  type = list(string)
+  default = []
+}
+
+variable "mongodb_max_throughput" {
+  description = "Max throughput of the MongoDB database - set in increments of 1,000 between 4,000 and 1,000,000"
+  type = number
+  default = 4000
+}

--- a/infrastructure/environments/variables.tf
+++ b/infrastructure/environments/variables.tf
@@ -14,20 +14,67 @@ variable "prefix" {
   type = string
 }
 
+variable "key_vault_id" {
+  description = "Key Vault ID"
+  type = string
+}
+
 /*
   Container Registry
  */
 
 variable "container_registry_name" {
   description = "Name of the container registry"
-  default = "pinscommonukscontainersprod"
   type = string
 }
 
 variable "container_registry_rg_name" {
   description = "Name of the registry's resource group"
-  default = "pinscommon-uks-containers-prod"
   type = string
+}
+
+/*
+  Kubernetes
+ */
+
+variable "k8s_availability_zones" {
+  description = "Zones to run the node pools in"
+  type = list(string)
+  default = null
+}
+
+variable "k8s_rbac_admin_groups" {
+  description = "List of AAD groups that have admin rights on the cluster"
+  type = set(string)
+  default = []
+}
+
+variable "k8s_rbac_enabled" {
+  description = "Enable RBAC on cluster"
+  type = bool
+  default = true
+}
+
+variable "k8s_min_nodes" {
+  description = "Minimum number of nodes per pool"
+  type = number
+  default = 1
+}
+
+variable "k8s_max_nodes" {
+  description = "Maximum number of nodes per pool"
+  type = number
+  default = 3
+}
+
+variable "k8s_version_prefix" {
+  description = "Version prefix to use - ensure you end with dot (.)"
+  default = "1.18."
+}
+
+variable "k8s_vm_size" {
+  description = "VM size"
+  default = "Standard_DS2_v2"
 }
 
 /*

--- a/infrastructure/k8s/cert-manager/letsencrypt-clusterissuer.yaml
+++ b/infrastructure/k8s/cert-manager/letsencrypt-clusterissuer.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: test@test.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: test@test.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/infrastructure/k8s/cert-manager/test-resource.yaml
+++ b/infrastructure/k8s/cert-manager/test-resource.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-test
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: test-selfsigned
+  namespace: cert-manager-test
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: selfsigned-cert
+  namespace: cert-manager-test
+spec:
+  dnsNames:
+    - example.com
+  secretName: selfsigned-cert-tls
+  issuerRef:
+    name: test-selfsigned

--- a/infrastructure/k8s/helm-dependencies.yaml
+++ b/infrastructure/k8s/helm-dependencies.yaml
@@ -1,0 +1,5 @@
+# Dependencies for the Flux Helm operator. Add "name" and "url" for chart repos
+
+configureRepositories:
+  enable: false # Change to true if setting repositories
+  repositories: []

--- a/infrastructure/k8s/nginx-ingress/README.md
+++ b/infrastructure/k8s/nginx-ingress/README.md
@@ -1,0 +1,13 @@
+# Nginx Ingress
+
+This folder exists to provide environment-specific configuration for the
+Nginx Ingress controller.
+
+By default, these files are empty. Typically, this might be used to specify
+an IP for the load balancer to use.
+
+```yaml
+controller:
+  service:
+    loadBalancerIP: 10.20.30.40
+```

--- a/infrastructure/k8s/nginx-ingress/common.yaml
+++ b/infrastructure/k8s/nginx-ingress/common.yaml
@@ -1,0 +1,12 @@
+controller:
+  replicaCount: 2
+  nodeSelector:
+    kubernetes.io/os: linux
+  service:
+    externalTrafficPolicy: Local
+  config:
+    http-redirect-code: "301"
+defaultBackend:
+  enabled: false
+rbac:
+  create: true

--- a/infrastructure/k8s/nginx-ingress/dev.yaml
+++ b/infrastructure/k8s/nginx-ingress/dev.yaml
@@ -1,0 +1,5 @@
+controller:
+  config:
+    # Allow use of LetsEncrypt staging certs in dev
+    hsts: "false"
+    hsts-include-subdomains: "false"

--- a/infrastructure/k8s/setup.sh
+++ b/infrastructure/k8s/setup.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+kubectl create namespace "${DEPLOY_NAMESPACE}" || true
+
+add_registry_secret() {
+  echo "Adding registry secret to ${DEPLOY_NAMESPACE}"
+
+  kubectl create secret docker-registry \
+    -n "${DEPLOY_NAMESPACE}" \
+    azure-docker-registry \
+    --docker-server="${DOCKER_SERVER}" \
+    --docker-username="${DOCKER_USERNAME}" \
+    --docker-password="${DOCKER_PASSWORD}" \
+    --docker-email="${EMAIL_ADDRESS}" \
+    -o yaml --dry-run=client | \
+    kubectl replace -n "${DEPLOY_NAMESPACE}" --force -f -
+}
+
+install_nginx_ingress() {
+  echo "Adding Nginx Ingress"
+
+  touch "${DIR}/nginx-ingress/${CLUSTER}.yaml"
+
+  kubectl create namespace nginx-ingress || true
+  helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+  helm repo update
+#    --set "controller.service.annotations.service\.beta\.kubernetes\.io\/azure-load-balancer-resource-group=$(get_tf_output "kube_load_balancer_rg")" \
+#    --set "controller.service.loadBalancerIP=$(get_tf_output "kube_load_balancer_ip")" \
+  helm upgrade \
+    --reset-values \
+    --install \
+    --wait \
+    --atomic \
+    --cleanup-on-fail \
+    --namespace nginx-ingress \
+    --values "${DIR}/nginx-ingress/common.yaml" \
+    --values "${DIR}/nginx-ingress/${CLUSTER}.yaml" \
+    nginx-ingress \
+    ingress-nginx/ingress-nginx
+}
+
+install_cert_manager() {
+  echo "Adding Cert Manager v${CERT_MANAGER_VERSION}"
+
+  kubectl create namespace cert-manager || true
+  helm repo add jetstack https://charts.jetstack.io
+  helm repo update
+  helm upgrade \
+    --reset-values \
+    --install \
+    --wait \
+    --atomic \
+    --cleanup-on-fail \
+    --namespace cert-manager \
+    --version "${CERT_MANAGER_VERSION}" \
+    --set installCRDs=true \
+    --set ingressShim.defaultIssuerName=letsencrypt-staging \
+    --set ingressShim.defaultIssuerKind=ClusterIssuer \
+    cert-manager \
+    jetstack/cert-manager
+   kubectl get pods --namespace cert-manager
+   kubectl apply -f "${DIR}/cert-manager/test-resource.yaml"
+   kubectl describe certificate -n cert-manager-test
+   kubectl delete -f "${DIR}/cert-manager/test-resource.yaml"
+   sed -i -e "s/email:.*/email: ${EMAIL_ADDRESS}/" "${DIR}/cert-manager/letsencrypt-clusterissuer.yaml"
+   kubectl apply -n cert-manager -f "${DIR}/cert-manager/letsencrypt-clusterissuer.yaml"
+}
+
+install_gitops() {
+  echo "Adding GitOps"
+
+  helm repo add fluxcd https://charts.fluxcd.io
+  kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/crds.yaml
+  kubectl create namespace flux || true
+  ssh-keyscan "${REPO_DOMAIN}" > ./known_hosts
+  helm upgrade \
+    --reset-values \
+    --install \
+    --wait \
+    --atomic \
+    --cleanup-on-fail \
+    --set git.url="git@${REPO_DOMAIN}:${REPO_URL}.git" \
+    --set git.path="releases/${CLUSTER}" \
+    --set git.branch="${DEFAULT_BRANCH}" \
+    --set git.label="${CLUSTER}-flux-sync" \
+    --set git.ciSkip="true" \
+    --namespace flux \
+    flux \
+    fluxcd/flux
+  helm upgrade \
+    --reset-values \
+    --install \
+    --wait \
+    --atomic \
+    --cleanup-on-fail \
+    --set-file ssh.known_hosts=./known_hosts \
+    --set git.ssh.secretName=flux-git-deploy \
+    --set helm.versions=v3 \
+    --set syncGarbageCollection.enabled=true \
+    --values="${DIR}/helm-dependencies.yaml" \
+    --namespace flux \
+    helm-operator \
+    fluxcd/helm-operator
+
+  # Add Flux public key as GitHub deploy key
+  PUBLIC_KEY=$(kubectl -n flux logs deployment/flux | grep identity.pub | cut -d '"' -f2)
+  KEY_NAME="${CLUSTER}_cluster_k8s_gitops"
+
+  # Get list of existing keys
+  echo "Getting existing deployment keys"
+  EXISTING_KEYS=$(curl -LsSf \
+    -H "Authorization: token ${REPO_TOKEN}" \
+    "${REPO_API_URL}/repos/${REPO_URL}/keys" | \
+    jq -r --arg KEY_NAME "$KEY_NAME" '.[] | select(.title==$KEY_NAME) | .id')
+
+  # Delete existing key
+  echo "Deleting duplicate deployment keys for ${KEY_NAME}"
+  for key in ${EXISTING_KEYS}
+    do
+      curl -LSf \
+        -H "Authorization: token ${REPO_TOKEN}" \
+        --request DELETE \
+        "${REPO_API_URL}/repos/${REPO_URL}/keys/${key}"
+    done
+
+  # Add new key
+  echo "Adding new ${KEY_NAME} deploy key to GitHub"
+  curl -LsSf \
+    --request POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: token ${REPO_TOKEN}" \
+    --data "{ \"title\": \"${KEY_NAME}\", \"key\": \"${PUBLIC_KEY}\", \"read_only\": false }" \
+    "${REPO_API_URL}/repos/${REPO_URL}/keys"
+}
+
+add_registry_secret
+install_nginx_ingress
+install_cert_manager
+install_gitops

--- a/infrastructure/scripts/lockResourceGroups.sh
+++ b/infrastructure/scripts/lockResourceGroups.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+ACTION="${1}" # Can be either "lock" or "unlock"
+ENV_NAME="${2}"
+APP_NAME="${3}"
+
+LOCK_NAME="SYSTEM_LOCK"
+
+echo "Apply ${ACTION} command for app=${APP_NAME} and env=${ENV_NAME}"
+
+groupList=$(az group list | jq \
+  --arg APP_NAME "${APP_NAME}" \
+  --arg ENV_NAME "${ENV_NAME}" \
+  'map(select((.tags.app==$APP_NAME) and (.tags.env==$ENV_NAME)))')
+
+for rg in $(echo "${groupList}" | jq -r '.[].name')
+do
+  case "${ACTION}" in
+    lock )
+      lockType=$(echo "${groupList}" | jq -r \
+        --arg NAME "${rg}" \
+        '.[] | select(.name==$NAME) | .tags.lock')
+
+      if [ "${lockType}" == "null" ];
+      then
+        echo "Lock type not set - not locking: ${rg}"
+        continue
+      fi
+
+      echo "Locking resource group ${rg} with type ${lockType}"
+
+      az lock create \
+        --lock-type "${lockType}" \
+        --name="${LOCK_NAME}" \
+        --resource-group "${rg}" > /dev/null
+      ;;
+    unlock )
+      echo "Unlocking ${rg}"
+
+      az lock delete \
+        --name="${LOCK_NAME}" \
+        --resource-group "${rg}" > /dev/null
+      ;;
+
+    * )
+      echo "Unknown command: ${ACTION}"
+      exit 1
+      ;;
+  esac
+
+done
+
+echo "All groups:"
+az group list | jq -r '.[].name'

--- a/releases/dev/app.yml
+++ b/releases/dev/app.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: app
+  namespace: app-dev
+  annotations:
+    fluxcd.io/automated: "true"
+    filter.fluxcd.io/tag.formsWebApp: semver:^1.0
+spec:
+  releaseName: app
+  chart:
+    git: git@github.com:foundry4/appeal-planning-decision.git
+    path: charts/app
+  rollback:
+    enable: true
+  values:
+    formsWebApp:
+      image:
+        repository: pinscommonukscontainersdefault.azurecr.io/forms-web-app
+        tag: 1.0.0
+
+    ingress:
+      host: dev.thesausage.blog


### PR DESCRIPTION
This is the base process for building the infrastructure and configuring the release mechanism.

# Infrastructure

The infrastructure is built using Terraform to ensure repeatability. There are two sections:
 - `/infrastructure/common`: common pieces of infrastructure, effectively assigned to the subscription
 - `/infrastructure/environments`: the different environment stacks

## Common

This is infrastructure that is common to the subscription. This is for things where it makes sense for only one, shared instance throughout the application. Things that belong in here are the likes of the container registry, or the key vault. For instance, the container registry will have Docker images published which will be deployed between all environments (it's poor practice to build artifacts between releases - using the version that was tested in all environments).

## Environments

This is the where the application will be run. This current version produces a Kubernetes cluster which, currently, is the entirety of the infrastructure. Future iterations will have CosmosDB, storage accounts etc although currently not required.

# GitHub Actions

There are actions added to run the infrastructures on a per-environment basis. Currently, only `dev` is configured - future environments will be iterated shortly.

## To Do
- There is currently a manual process to associate the IP address of the load balancer. Need to understand how this will be linked up with the .gov.uk domain name so will leave as manual until I have answers.

# Releases

Releases are done using the GitOps workflow. Lots can be found about [GitOps online](https://www.gitops.tech/), but in summary, we have a release manifest (in `/releases`) which describes the Helm charts (in `/charts/app`). The release manifest has a few variables, but the important ones are the image and the tag to track, the URL of the Docker registry and any variables which we want to apply (in this instance, just the URL)

Currently, this is only the `forms-web-app` as there is no release for the `appeals-service-api` - this can be iterated quickly