### PR TITLE
chore(setup): remove the npm ci from the docker run commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+SERVICES_DIR ?= "services"
+
+down:
+	docker-compose down
+.PHONY: down
+
+install:
+	(cd data && npm ci)
+
+	for dir in ${SERVICES_DIR}/*; do \
+		(cd $${dir} && npm ci); \
+  	done
+.PHONY: install
+
+serve:
+	docker-compose up
+.PHONY: serve
+
+uninstall:
+	(cd data && rm -Rf node_modules)
+
+	for dir in ${SERVICES_DIR}/*; do \
+		(cd $${dir} && rm -Rf node_modules); \
+  	done
+.PHONY: uninstall

--- a/README.md
+++ b/README.md
@@ -2,10 +2,35 @@
 
 Monorepo for all PINS Appeal planning decision services and infrastructure
 
+## TL;DR
+
+- `make install`
+- `make serve`
+- Go to [localhost:9000](http://localhost:9000)
+
 ## Pre-requisites
 
+- [NodeJS v14](https://nodejs.org/en/download/)
 - [Docker](https://docs.docker.com/get-docker/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
+
+## NodeJS
+
+Install NodeJS using [nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
+
+```
+nvm install 14
+nvm use 14
+nvm alias default 14
+```
+
+### Dependencies
+
+You will need to install the dependencies locally, even though we're using 
+Docker Compose to run locally.
+
+The easiest way to do that is to run `make install`, which will cycle through
+every folder and install npm dependencies.
 
 ## Running
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - mongodb
     volumes:
       - ./services/appeals-service-api:/opt/app
-    command: sh -c "npm ci && npm run start:dev"
+    command: npm run start:dev
 
   forms-web-app:
     image: node:14-alpine
@@ -35,7 +35,7 @@ services:
       - appeals-service-api
     volumes:
       - ./services/forms-web-app:/opt/app
-    command: sh -c "npm ci && npm run start:dev"
+    command: npm run start:dev
 
   # Populate the database with data - one instance per service
   appeals-service-api-data:
@@ -51,7 +51,7 @@ services:
       SOURCE_DIR: appeals-service-api
       MONGODB_URL: mongodb://mongodb:27017/appeals-service-api
     restart: on-failure
-    command: sh -c "npm ci && npm start"
+    command: npm start
 
   # Third-party services
   mongodb:


### PR DESCRIPTION
This was working on Linux, but killing Macs