### PR TITLE
fix(assets): change how assets are linked

### DIFF
--- a/forms-web-app/src/app.js
+++ b/forms-web-app/src/app.js
@@ -16,10 +16,10 @@ app.use(lusca.xssProtection(true));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use('/public', express.static(path.join(__dirname, '/public')));
+app.use('/public', express.static(path.join(__dirname, 'public')));
 app.use(
   '/assets',
-  express.static(path.join(__dirname, '../node_modules/govuk-frontend/govuk/assets'))
+  express.static(path.join(__dirname, '..', 'node_modules', 'govuk-frontend', 'govuk', 'assets'))
 );
 
 // Routes
@@ -39,8 +39,8 @@ const nunjucksConfig = {
 };
 
 const viewPaths = [
-  path.join(__dirname, '../node_modules/govuk-frontend'),
-  path.join(__dirname, '/views'),
+  path.join(__dirname, '..', 'node_modules', 'govuk-frontend'),
+  path.join(__dirname, 'views'),
 ];
 
 nunjucks.configure(viewPaths, nunjucksConfig);


### PR DESCRIPTION
The `path.join` is designed to be used with n arguments and then puts them together
with the appropriate path separator for the operating system. Even though this will
only ever run on Linux, we should use the functions how they're designed

This commit isn't much of an issue. It really exists to trigger a new release of the
form-web-app after all the problems we've had with getting it working.