### PR TITLE
Fix/commit messaging

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -2,6 +2,7 @@ name: Check commit message
 
 on:
   - push
+  - pull_request
 
 jobs:
   lint:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "commit": "cz",
-    "commitlint": "commitlint --from 38b2eaa --to HEAD",
+    "commitlint": "commitlint --from 60c94b6 --to HEAD",
     "format": "prettier --write \"*.js\" \"data/*.js\"",
     "semantic-release": "semantic-release",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -37,7 +37,8 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "cd ./forms-web-app && lint-staged"
+      "pre-commit": "cd ./forms-web-app && lint-staged",
+      "pre-push": "npm run commitlint"
     }
   }
 }


### PR DESCRIPTION
Commit messaging broken by b5f3365 and ca0560d. This should have been picked up by the commit lint job and prevented merging, so not sure how that got through.

Have added `pull_request` event to the commit lint job which _SHOULD_ fix it (hopefully).