### PR TITLE
chore(release): remove changelog and versioned package.json in a new …

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,24 +7,6 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
   ],
-  "prepare": [
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG"
-      }
-    ],
-    "@semantic-release/npm",
-    {
-      "path": "@semantic-release/git",
-      "assets": [
-        "CHANGELOG",
-        "package.json",
-        "package-lock.json"
-      ],
-      "message": "chore(release): ${nextRelease.version} [ci skip]"
-    }
-  ],
   "verifyConditions": [
     {
       "path": "@semantic-release/github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,48 +499,6 @@
         "@types/node": ">= 8"
       }
     },
-    "@semantic-release/changelog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-5.0.1.tgz",
-      "integrity": "sha512-unvqHo5jk4dvAf2nZ3aw4imrlwQ2I50eVVvq9D47Qc3R+keNqepx1vDYwkjF8guFXnOYaYcR28yrZWno1hFbiw==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "^2.1.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^9.0.0",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true
-        }
-      }
-    },
     "@semantic-release/commit-analyzer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "commitizen": "^4.2.2",
     "husky": "^4.3.0",


### PR DESCRIPTION
…release

With the current GitHub setup of only allowing merges into the master branch, we cannot push a
versioned package.json or a CHANGELOG file to the master branch. This does not affect the versioning
on the release in any way and the GitHub release page retains the changelog.