### PR TITLE
fix(invalid-date): added condtional rendering of dateInput macro to show errors

### DIFF
--- a/forms-web-app/src/controllers/eligibility.js
+++ b/forms-web-app/src/controllers/eligibility.js
@@ -10,7 +10,7 @@ exports.getDecisionDate = (req, res) => {
 
 exports.postDecisionDate = (req, res) => {
   const { body } = req;
-  const { errors } = body;
+  const { errors = [] } = body;
 
   // TO DO: Move this validation out to a service and try to
   // build a custom validator in express-validator

--- a/forms-web-app/src/views/eligibility/decision-date.njk
+++ b/forms-web-app/src/views/eligibility/decision-date.njk
@@ -16,7 +16,7 @@
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
           <li>
-            <a href="#date-error">You need to provide a valid date</a>
+            <a href="#date-error">You need to provide a date</a>
           </li>
         </ul>
       </div>
@@ -28,20 +28,53 @@
     <form action="/eligibility/decision-date" method="POST">
 
       <div class="govuk-form-group {% if errors %} govuk-form-group--error {% endif %}">
-      {{ govukDateInput({
-        id: "decision-date",
-        namePrefix: "decision-date",
-        fieldset: {
-          legend: {
-            text: "What's the decision date on the letter from the local planning department?",
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--l"
+      {% if errors %}
+        {% set dateInputParams = {
+          id: "decision-date",
+          namePrefix: "decision-date",
+          fieldset: {
+            legend: {
+              text: "What's the decision date on the letter from the local planning department?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "For example, 20 04 2020"
+          },
+          errorMessage: {
+            text: "You need to provide a date"
+          },
+          items: [
+              {
+                classes: "govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error"
+              },
+              {
+                classes: "govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error"
+              },
+              {
+                classes: "govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error"
+              }
+          ]
+        } %}
+      {% else %}
+        {% set dateInputParams = {
+          id: "decision-date",
+          namePrefix: "decision-date",
+          fieldset: {
+            legend: {
+              text: "What's the decision date on the letter from the local planning department?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "For example, 20 04 2020"
           }
-        },
-        hint: {
-          text: "For example, 20 04 2020"
-        }
-      }) }}
+        } %}
+      {% endif %}
+
+      {{ govukDateInput(dateInputParams) }}
 
       <p class="govuk-body govuk-!-margin-bottom-7">
         <a class="govuk-link" href="/eligibility/no-decision">I have not received a decision from the local planning department​</a>


### PR DESCRIPTION
## Changes

- Added a condition in the decision-date nunjucks template to render a date input differently if errors have been found.

<img width="833" alt="Screenshot 2020-11-02 at 18 32 16" src="https://user-images.githubusercontent.com/325329/97905378-c4fa2000-1d39-11eb-9fef-d2444f04d319.png">
