### PR TITLE
Fix git pull tag in set version

### DIFF
--- a/.github/actions/flux/action.yml
+++ b/.github/actions/flux/action.yml
@@ -1,0 +1,23 @@
+name: Flux
+description: Manage interaction with Flux
+inputs:
+  FLUX_TAG:
+    description: Flux tag
+    default: "-flux-sync"
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Remove local Flux tag
+      shell: bash
+      run: |
+        git fetch -tp -f --all
+
+        for tag in $(git tag)
+        do
+          if [[ "$tag" =~ ^.*${{ inputs.FLUX_TAG }} ]]
+          then
+            echo "Deleting tag: ${tag}"
+            git tag -d "$tag" || true
+          fi
+        done

--- a/.github/workflows/appeals-service-api.yml
+++ b/.github/workflows/appeals-service-api.yml
@@ -93,6 +93,9 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           VERSION: ${{ steps.vars.outputs.new_version }}
 
+      - uses: ./.github/actions/flux
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+
       - name: Set next version number
         uses: ./.github/actions/semantic-release
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}

--- a/.github/workflows/forms-web-app.yml
+++ b/.github/workflows/forms-web-app.yml
@@ -91,6 +91,9 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           VERSION: ${{ steps.vars.outputs.new_version }}
 
+      - uses: ./.github/actions/flux
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+
       - name: Set next version number
         uses: ./.github/actions/semantic-release
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}


### PR DESCRIPTION
The semantic release mechanism does not allow for tags to be clobbered locally. This breaks the flux tag, which changes dependent upon what's detected by flux on the cluster(s)