### PR TITLE
chore: add eslintignore to each package

### DIFF
--- a/appeals-service-api/.eslintignore
+++ b/appeals-service-api/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/forms-web-app/.eslintignore
+++ b/forms-web-app/.eslintignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Eslint not ignoring node_modules on Macs