### PR TITLE
refactor(e2e-tests): added wait config for cypress tests

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,20 @@
+# Cypress E2E tests
+
+### Overview
+
+The [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html#In-a-nutshell) framework provides support 
+for automated testing and BDD. 
+
+#### Video artefacts
+
+Each test run can generate a video record of the tests and the browser behaviour. In addition to their use in 
+ci pipelines and local development, these recordings have potential to serve as evidence of delivery of required 
+behaviour e.g. played at demo events. Typically, the tests should complete as quickly as possible and this should be 
+the default. However, when producing video artefacts intended to be presented it may be convenient to manage periods 
+of waiting or pausing during the test execution. Environment variables can be used for this configuration and one 
+named `demoDelay` is provided in the `cypress.json` file. The variable can be used in statements 
+like `cy.wait(Cypress.env('demoDelay'))` to control wait times i.e. the value is the required delay in milliseconds.
+From the `e2e-tests` folder, the tests can be run locally setting the delay period with commands like:
+```
+node_modules/cypress/bin/cypress run --headed -b chrome --env demoDelay=1000
+```

--- a/e2e-tests/cypress.json
+++ b/e2e-tests/cypress.json
@@ -2,5 +2,9 @@
   "baseUrl": "http://localhost:9000",
   "testFiles": "**/*.feature",
   "chromeWebSecurity": false,
-  "projectId": "i4z1d2"
+  "viewportWidth": 1000,
+  "viewportHeight":1280,
+  "env": {
+    "demoDelay": 0
+  }
 }

--- a/e2e-tests/cypress/integration/PageObjects/PO_EligibilityDecisionDate.js
+++ b/e2e-tests/cypress/integration/PageObjects/PO_EligibilityDecisionDate.js
@@ -115,7 +115,9 @@ class PO_EligibilityDecisionDate {
     }
 
     continueBtn() {
+        cy.wait(Cypress.env('demoDelay'))
         const continueBtn = cy.get('.govuk-button').click()
+        cy.wait(Cypress.env('demoDelay'))
     }
 
 


### PR DESCRIPTION
Introduced config (env var) to set wait interval for use in cypress e2e tests to help generate videos
suitable for demos etc. Also updated viewport height so that whole pages are captured in the videos.

## Ticket Number
UCD-988

## Description of change
Small refactoring step to support configuration of waiting/pausing in e2e tests.

## Checklist
- [ ] Requires infrastructure changes
- [x] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
