### PR TITLE
fix(forms-web-app): add further coverage to meet new jest minimums

### DIFF
--- a/forms-web-app/jest.config.js
+++ b/forms-web-app/jest.config.js
@@ -9,10 +9,10 @@ module.exports = {
   coverageReporters: ['json', 'html', 'text', 'text-summary'],
   coverageThreshold: {
     global: {
-      branches: 76,
-      functions: 80,
-      lines: 75,
-      statements: 75,
+      branches: 81,
+      functions: 87,
+      lines: 81,
+      statements: 81,
     },
   },
 };

--- a/forms-web-app/src/app.js
+++ b/forms-web-app/src/app.js
@@ -14,16 +14,7 @@ require('express-async-errors');
 
 const config = require('./config');
 const logger = require('./lib/logger');
-
-const applicationNameRouter = require('./routes/application-name');
-const applicationNumberRouter = require('./routes/application-number');
-const checkAnswersRouter = require('./routes/check-answers');
-const confirmationRouter = require('./routes/confirmation');
-const eligibilityRouter = require('./routes/eligibility');
-const indexRouter = require('./routes/index');
-const submissionRouter = require('./routes/submission');
-const taskListRouter = require('./routes/task-list');
-const yourDetailsRouter = require('./routes/your-details');
+const routes = require('./routes');
 
 const app = express();
 
@@ -72,15 +63,7 @@ app.use(
 );
 
 // Routes
-app.use('/', indexRouter);
-app.use('/application-name', applicationNameRouter);
-app.use('/application-number', applicationNumberRouter);
-app.use('/check-answers', checkAnswersRouter);
-app.use('/confirmation', confirmationRouter);
-app.use('/eligibility', eligibilityRouter);
-app.use('/submission', submissionRouter);
-app.use('/task-list', taskListRouter);
-app.use('/your-details', yourDetailsRouter);
+app.use('/', routes);
 
 // View Engine
 app.set('view engine', 'njk');

--- a/forms-web-app/src/routes/home.js
+++ b/forms-web-app/src/routes/home.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const indexController = require('../controllers/index');
+
+const router = express.Router();
+
+/* GET home page. */
+router.get('/', indexController.getIndex);
+
+module.exports = router;

--- a/forms-web-app/src/routes/index.js
+++ b/forms-web-app/src/routes/index.js
@@ -1,9 +1,25 @@
 const express = require('express');
-const indexController = require('../controllers/index');
 
 const router = express.Router();
 
-/* GET home page. */
-router.get('/', indexController.getIndex);
+const applicationNameRouter = require('./application-name');
+const applicationNumberRouter = require('./application-number');
+const checkAnswersRouter = require('./check-answers');
+const confirmationRouter = require('./confirmation');
+const eligibilityRouter = require('./eligibility');
+const homeRouter = require('./home');
+const submissionRouter = require('./submission');
+const taskListRouter = require('./task-list');
+const yourDetailsRouter = require('./your-details');
+
+router.use('/', homeRouter);
+router.use('/application-name', applicationNameRouter);
+router.use('/application-number', applicationNumberRouter);
+router.use('/check-answers', checkAnswersRouter);
+router.use('/confirmation', confirmationRouter);
+router.use('/eligibility', eligibilityRouter);
+router.use('/submission', submissionRouter);
+router.use('/task-list', taskListRouter);
+router.use('/your-details', yourDetailsRouter);
 
 module.exports = router;

--- a/forms-web-app/tests/unit/controllers/confirmation.test.js
+++ b/forms-web-app/tests/unit/controllers/confirmation.test.js
@@ -7,9 +7,19 @@ const res = mockRes();
 describe('controller/confirmation', () => {
   describe('getConfirmation', () => {
     it('should call the correct template', () => {
-      confirmationController.getConfirmation(req, res);
+      const appellantEmail = 'hello@example.com';
+      const r = {
+        ...req,
+        session: {
+          ...req.session,
+          appeal: {
+            'appellant-email': appellantEmail,
+          },
+        },
+      };
+      confirmationController.getConfirmation(r, res);
 
-      expect(res.render).toHaveBeenCalledWith('confirmation/index', { appellantEmail: undefined });
+      expect(res.render).toHaveBeenCalledWith('confirmation/index', { appellantEmail });
     });
   });
 });

--- a/forms-web-app/tests/unit/controllers/index.test.js
+++ b/forms-web-app/tests/unit/controllers/index.test.js
@@ -1,0 +1,15 @@
+const indexController = require('../../../src/controllers/index');
+const { mockReq, mockRes } = require('../mocks');
+
+const req = mockReq();
+const res = mockRes();
+
+describe('controller/index', () => {
+  describe('getSubmission', () => {
+    it('should call the correct template', () => {
+      indexController.getIndex(req, res);
+
+      expect(res.render).toHaveBeenCalledWith('index');
+    });
+  });
+});

--- a/forms-web-app/tests/unit/controllers/submission.test.js
+++ b/forms-web-app/tests/unit/controllers/submission.test.js
@@ -31,8 +31,28 @@ describe('controller/submission', () => {
       });
     });
 
-    xit('should log an error if the api call fails, and remain on the same page', async () => {});
+    it('should redirect back to /submission if validation passes but `i-agree` not given', async () => {
+      const mockRequest = {
+        ...req,
+        body: {
+          'appellant-confirmation': 'anything here - not valid',
+        },
+      };
+      submissionController.postSubmission(mockRequest, res);
 
-    xit('should redirect if valid', async () => {});
+      expect(res.redirect).toHaveBeenCalledWith('/submission');
+    });
+
+    it('should redirect if valid', async () => {
+      const mockRequest = {
+        ...req,
+        body: {
+          'appellant-confirmation': 'i-agree',
+        },
+      };
+      await submissionController.postSubmission(mockRequest, res);
+
+      expect(res.redirect).toHaveBeenCalledWith('/confirmation');
+    });
   });
 });

--- a/forms-web-app/tests/unit/lib/appeals-api-wrapper.test.js
+++ b/forms-web-app/tests/unit/lib/appeals-api-wrapper.test.js
@@ -2,61 +2,83 @@ jest.mock('uuid');
 
 const fetch = require('node-fetch');
 const uuid = require('uuid');
-const { createOrUpdateAppeal } = require('../../../src/lib/appeals-api-wrapper');
+const {
+  createOrUpdateAppeal,
+  getExistingAppeal,
+  getLPAList,
+} = require('../../../src/lib/appeals-api-wrapper');
 const config = require('../../../src/config');
 
 config.appeals.url = 'http://fake.url';
 
 describe('lib/appeals-api-wrapper', () => {
-  [
-    {
-      title: 'POST when a uuid is missing',
-      given: () => {
-        fetch.mockResponseOnce(JSON.stringify({ good: 'data' }));
+  describe('createOrUpdateAppeal', () => {
+    [
+      {
+        title: 'POST when a uuid is missing',
+        given: () => {
+          fetch.mockResponseOnce(JSON.stringify({ good: 'data' }));
 
-        return {
-          a: 'b',
-          uuid: undefined,
-        };
+          return {
+            a: 'b',
+            uuid: undefined,
+          };
+        },
+        expected: (appealsApiResponse) => {
+          expect(fetch).toHaveBeenCalledWith(`${config.appeals.url}/appeals`, {
+            body: '{"a":"b"}',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Correlation-ID': uuid.v4(),
+            },
+            method: 'POST',
+          });
+          expect(appealsApiResponse).toEqual({ good: 'data' });
+        },
       },
-      expected: (appealsApiResponse) => {
-        expect(fetch).toHaveBeenCalledWith(`${config.appeals.url}/appeals`, {
-          body: '{"a":"b"}',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Correlation-ID': uuid.v4(),
-          },
-          method: 'POST',
-        });
-        expect(appealsApiResponse).toEqual({ good: 'data' });
-      },
-    },
-    {
-      title: 'PUT when a uuid is provided',
-      given: () => {
-        fetch.mockResponseOnce(JSON.stringify({ shouldBe: 'valid' }));
+      {
+        title: 'PUT when a uuid is provided',
+        given: () => {
+          fetch.mockResponseOnce(JSON.stringify({ shouldBe: 'valid' }));
 
-        return {
-          c: 'd',
-          uuid: '123-abc',
-        };
+          return {
+            c: 'd',
+            uuid: '123-abc',
+          };
+        },
+        expected: (appealsApiResponse) => {
+          expect(fetch).toHaveBeenCalledWith(`${config.appeals.url}/appeals/123-abc`, {
+            body: '{"c":"d","uuid":"123-abc"}',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Correlation-ID': uuid.v4(),
+            },
+            method: 'PUT',
+          });
+          expect(appealsApiResponse).toEqual({ shouldBe: 'valid' });
+        },
       },
-      expected: (appealsApiResponse) => {
-        expect(fetch).toHaveBeenCalledWith(`${config.appeals.url}/appeals/123-abc`, {
-          body: '{"c":"d","uuid":"123-abc"}',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Correlation-ID': uuid.v4(),
-          },
-          method: 'PUT',
-        });
-        expect(appealsApiResponse).toEqual({ shouldBe: 'valid' });
-      },
-    },
-  ].forEach(({ title, given, expected }) => {
-    it(`should ${title}`, async () => {
-      const appealsApiResponse = await createOrUpdateAppeal(given());
-      expected(appealsApiResponse);
+    ].forEach(({ title, given, expected }) => {
+      it(`should ${title}`, async () => {
+        const appealsApiResponse = await createOrUpdateAppeal(given());
+        expected(appealsApiResponse);
+      });
+    });
+  });
+
+  describe('getExistingAppeal', () => {
+    it(`should call the expected URL`, async () => {
+      fetch.mockResponseOnce(JSON.stringify({ shouldBe: 'valid' }));
+      await getExistingAppeal('123');
+      expect(fetch.mock.calls[0][0]).toEqual('http://fake.url/appeals/123');
+    });
+  });
+
+  describe('getLPAList', () => {
+    it(`should call the expected URL`, async () => {
+      fetch.mockResponseOnce(JSON.stringify({ shouldBe: 'valid' }));
+      await getLPAList();
+      expect(fetch.mock.calls[0][0]).toEqual('http://fake.url/local-planning-authorities');
     });
   });
 });

--- a/forms-web-app/tests/unit/routes/confirmation.test.js
+++ b/forms-web-app/tests/unit/routes/confirmation.test.js
@@ -1,0 +1,24 @@
+const { get } = require('./router-mock');
+const confirmationController = require('../../../src/controllers/confirmation');
+const fetchExistingAppealMiddleware = require('../../../src/middleware/fetch-existing-appeal');
+
+jest.mock('../../../src/middleware/fetch-existing-appeal');
+
+describe('routes/confirmation', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../src/routes/confirmation');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/',
+      [fetchExistingAppealMiddleware],
+      confirmationController.getConfirmation
+    );
+  });
+});

--- a/forms-web-app/tests/unit/routes/home.test.js
+++ b/forms-web-app/tests/unit/routes/home.test.js
@@ -1,0 +1,17 @@
+const { get } = require('./router-mock');
+const indexController = require('../../../src/controllers/index');
+
+describe('routes/index', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../src/routes/home');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith('/', indexController.getIndex);
+  });
+});

--- a/forms-web-app/tests/unit/routes/index.test.js
+++ b/forms-web-app/tests/unit/routes/index.test.js
@@ -1,5 +1,13 @@
-const { get } = require('./router-mock');
-const indexController = require('../../../src/controllers/index');
+const { use } = require('./router-mock');
+const applicationNameRouter = require('../../../src/routes/application-name');
+const applicationNumberRouter = require('../../../src/routes/application-number');
+const checkAnswersRouter = require('../../../src/routes/check-answers');
+const confirmationRouter = require('../../../src/routes/confirmation');
+const eligibilityRouter = require('../../../src/routes/eligibility');
+const homeRouter = require('../../../src/routes/home');
+const submissionRouter = require('../../../src/routes/submission');
+const taskListRouter = require('../../../src/routes/task-list');
+const yourDetailsRouter = require('../../../src/routes/your-details');
 
 describe('routes/index', () => {
   beforeEach(() => {
@@ -12,6 +20,15 @@ describe('routes/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(get).toHaveBeenCalledWith('/', indexController.getIndex);
+    expect(use).toHaveBeenCalledWith('/', homeRouter);
+    expect(use).toHaveBeenCalledWith('/application-name', applicationNameRouter);
+    expect(use).toHaveBeenCalledWith('/application-number', applicationNumberRouter);
+    expect(use).toHaveBeenCalledWith('/check-answers', checkAnswersRouter);
+    expect(use).toHaveBeenCalledWith('/confirmation', confirmationRouter);
+    expect(use).toHaveBeenCalledWith('/eligibility', eligibilityRouter);
+    expect(use).toHaveBeenCalledWith('/submission', submissionRouter);
+    expect(use).toHaveBeenCalledWith('/task-list', taskListRouter);
+    expect(use).toHaveBeenCalledWith('/your-details', yourDetailsRouter);
+    expect(use.mock.calls.length).toBe(9);
   });
 });

--- a/forms-web-app/tests/unit/routes/submission.test.js
+++ b/forms-web-app/tests/unit/routes/submission.test.js
@@ -1,0 +1,27 @@
+const { get, post } = require('./router-mock');
+const submissionController = require('../../../src/controllers/submission');
+const { validationErrorHandler } = require('../../../src/validators/validation-error-handler');
+const { rules: submissionValidationRules } = require('../../../src/validators/submission');
+
+jest.mock('../../../src/validators/submission');
+
+describe('routes/submission', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../src/routes/submission');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith('/', submissionController.getSubmission);
+    expect(post).toHaveBeenCalledWith(
+      '/',
+      submissionValidationRules(),
+      validationErrorHandler,
+      submissionController.postSubmission
+    );
+  });
+});


### PR DESCRIPTION
Extract routes to separate file, add missing coverage to controllers

## Ticket Number
<!-- Add the number from the Jira board -->
NA - fixup previous PR order merging issue with jest minimums

## Description of change
Extract routes to separate file, add missing coverage to controllers

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
