### PR TITLE
fix(key-vault): remove secrets from terraform

### DIFF
--- a/.github/workflows/infra-environments.yml
+++ b/.github/workflows/infra-environments.yml
@@ -124,6 +124,8 @@ jobs:
           echo "::set-output name=cluster_lb_ip_address::$(terraform output kube_load_balancer_ip)"
           echo "::set-output name=cluster_lb_ip_name::$(terraform output kube_load_balancer_domain_label)"
           echo "::set-output name=cluster_lb_ip_rg::$(terraform output kube_load_balancer_rg)"
+          echo "::set-output name=key_vault_name::$(terraform output key_vault_name)"
+          echo "::set-output name=key_vault_secrets::$(terraform output key_vault_secrets)"
 
       - name: Configure Kubernetes instance
         uses: ./.github/actions/kubectl-helm
@@ -138,6 +140,8 @@ jobs:
           DOCKER_SERVER: ${{ steps.tf_common.outputs.containers_server }}
           DOCKER_USERNAME: ${{ steps.tf_common.outputs.containers_username }}
           EMAIL_ADDRESS: ${{ secrets.DEVOPS_EMAIL_ADDRESS }}
+          KEY_VAULT_NAME: ${{ steps.tf_output.outputs.key_vault_name }}
+          KEY_VAULT_SECRETS: ${{ steps.tf_output.outputs.key_vault_secrets }}
           RELEASE_BRANCH: release
           REPO_API_URL: https://api.github.com
           REPO_DOMAIN: github.com

--- a/infrastructure/environments/README.md
+++ b/infrastructure/environments/README.md
@@ -52,8 +52,12 @@ Infrastructure which the applications are deployed to
 | containers\_password | Password for the container registry |
 | containers\_server | Server URL for the container registry |
 | containers\_username | Username for the container registry |
+| key\_vault\_name | Key vault name |
+| key\_vault\_secrets | Secrets JSON key/value pairs to be ingested into Key Vault - done externally to avoid Terraform refresh permissions errors. Values must be strings. |
 | kube\_load\_balancer\_domain\_label | The DNS label of the load balancer for the Kubernetes cluster |
 | kube\_load\_balancer\_ip | The IP of the load balancer for the Kubernetes cluster |
 | kube\_load\_balancer\_rg | The rosource group the load balancer IP exists in |
 | kubeconfig | The Kubernetes config file |
+| mongodb\_connection\_strings | MongoDB connection strings for each database |
+| redis\_connection\_strings | Redis connection strings for each cluster |
 

--- a/infrastructure/environments/applications.tf
+++ b/infrastructure/environments/applications.tf
@@ -12,9 +12,3 @@ resource "random_string" "fwa-session-key" {
   lower = true
   number = true
 }
-
-resource "azurerm_key_vault_secret" "fwa-session-key" {
-  key_vault_id = azurerm_key_vault.key_vault.id
-  name = "fwa-session-key"
-  value = random_string.fwa-session-key.result
-}

--- a/infrastructure/environments/key_vault.tf
+++ b/infrastructure/environments/key_vault.tf
@@ -37,7 +37,6 @@ resource "azurerm_key_vault" "key_vault" {
   }
 }
 
-
 resource "azurerm_key_vault_access_policy" "current-sp" {
   key_vault_id = azurerm_key_vault.key_vault.id
   object_id = data.azurerm_client_config.current.object_id

--- a/infrastructure/environments/mongodb.tf
+++ b/infrastructure/environments/mongodb.tf
@@ -64,14 +64,3 @@ module "mongodb-databases" {
   name = var.mongodb_databases[count.index].name
   collections = var.mongodb_databases[count.index].collections
 }
-
-resource "azurerm_key_vault_secret" "mongodb" {
-  for_each = toset([ for id, db in var.mongodb_databases :
-    db.name
-  ])
-  key_vault_id = azurerm_key_vault.key_vault.id
-  name = "mongodb-${each.value}-store"
-  value = jsonencode({
-    url = replace("${azurerm_cosmosdb_account.mongodb.connection_strings[0]}&retrywrites=false", "/?", "/${each.value}?")
-  })
-}

--- a/infrastructure/environments/redis.tf
+++ b/infrastructure/environments/redis.tf
@@ -23,14 +23,3 @@ resource "azurerm_redis_cache" "redis" {
   sku_name = var.redis_sku
   minimum_tls_version = "1.2"
 }
-
-resource "azurerm_key_vault_secret" "fwa-session-redis" {
-  key_vault_id = azurerm_key_vault.key_vault.id
-  name = "redis-fwa-session-store"
-  value = jsonencode({
-    host = tostring(azurerm_redis_cache.redis.hostname)
-    pass = tostring(azurerm_redis_cache.redis.primary_access_key)
-    port = tostring(azurerm_redis_cache.redis.ssl_port)
-    use_tls = "true"
-  })
-}

--- a/infrastructure/environments/storage.tf
+++ b/infrastructure/environments/storage.tf
@@ -29,9 +29,3 @@ resource "azurerm_storage_account" "documents" {
     }
   }
 }
-
-resource "azurerm_key_vault_secret" "docs-blob-storage-connection-string" {
-  key_vault_id = azurerm_key_vault.key_vault.id
-  name = "docs-blob-storage-connection-string"
-  value = azurerm_storage_account.documents.primary_connection_string
-}


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
n/a

## Description of change
<!-- Please describe the change -->
As the Key Vault networking is limited to Azure, the VNet and the IP of the machine running Terraform, secrets cannot be read during Terraform refresh. By moving it outside of Terraform and doing it as an upsert, this avoids this failing on future runs

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
