### PR TITLE
test(e2e-tests): add feature file for appeal statement submission

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -16,5 +16,7 @@ named `demoDelay` is provided in the `cypress.json` file. The variable can be us
 like `cy.wait(Cypress.env('demoDelay'))` to control wait times i.e. the value is the required delay in milliseconds.
 From the `e2e-tests` folder, the tests can be run locally setting the delay period with commands like:
 ```
-node_modules/cypress/bin/cypress run --headed -b chrome --env demoDelay=1000
+node_modules/cypress/bin/cypress run --headed -b chrome --env demoDelay=1000 -e TAGS="@wip"
 ```
+
+Note: In the example above only tests tagged with `@wip` will be selected to run.

--- a/e2e-tests/cypress/integration/appeal-statement-submission.feature
+++ b/e2e-tests/cypress/integration/appeal-statement-submission.feature
@@ -1,0 +1,77 @@
+@wip
+Feature: Appeal statement file submission
+
+  I want to submit an appeal statement.
+  An appeal can have an optional appeal statement in the form of a file uploaded and associated with the appeal.
+  The latest uploaded appeal statement file replaces any previously uploaded files.
+  Appeal statements files that contain sensitive information are not permitted.
+  Valid appeal statement files must:
+  * be one of the white-listed types i.e. doc, docx, pdf, tif, tiff, jpg, jpeg and png,
+  * not exceed a size limit and
+  * not be password-protected if doc, docx or pdf.
+
+  Scenario Outline: Valid appeal statement file without sensitive information
+    Given I have an appeal statement file <filename> "without" sensitive information
+    When I submit the appeal statement file
+    Then I can see that the file <filename> "is" submitted
+    Examples:
+      | filename                      |
+      | "appeal-statement-valid.doc"  |
+      | "appeal-statement-valid.docx" |
+      | "appeal-statement-valid.pdf"  |
+      | "appeal-statement-valid.tif"  |
+      | "appeal-statement-valid.tiff"  |
+      | "appeal-statement-valid.jpg"  |
+      | "appeal-statement-valid.jpeg"  |
+      | "appeal-statement-valid.png"  |
+
+  Scenario Outline: Valid appeal statement file without sensitive information overwrites previous file
+    Given I have previously submitted an appeal statement file <previous-filename>
+    And I have an appeal statement file <replacement-filename> "without" sensitive information
+    When I submit the appeal statement file
+    Then I can see that the file <replacement-filename> "is" submitted
+    Examples:
+      | previous-filename            | replacement-filename         |
+      | "appeal-statement-valid.pdf" | "appeal-statement-valid.doc" |
+
+  Scenario Outline: Valid appeal statement file with sensitive information does not overwrite previous file
+    Given I have previously submitted an appeal statement file <previous-filename>
+    And I have an appeal statement file <replacement-filename> "with" sensitive information
+    When I submit the appeal statement file
+    Then I am informed why the file is not submitted
+    And I can see that the file <previous-filename> "is" submitted
+    Examples:
+      | previous-filename            | replacement-filename         |
+      | "appeal-statement-valid.pdf" | "appeal-statement-valid.doc" |
+
+  Scenario Outline: Valid appeal statement file with sensitive information
+    Given I have an appeal statement file <filename> "with" sensitive information
+    When I submit the appeal statement file
+    Then I can see that the file <filename> "is not" submitted
+    And I am informed why the file is not submitted
+    Examples:
+      | filename                     |
+      | "appeal-statement-valid.doc" |
+
+  Scenario Outline: Invalid appeal statement file without sensitive information
+    Given I have an appeal statement file <filename> "without" sensitive information
+    When I submit the appeal statement file
+    Then I can see that the file <filename> "is not" submitted
+    And I am informed why the file is not submitted
+    Examples:
+      | filename                                            |
+      | "appeal-statement-invalid-wrong-type.csv"           |
+      | "appeal-statement-invalid-exceeds-maximum-size.pdf" |
+      | "appeal-statement-invalid-password-protected.doc"   |
+      | "appeal-statement-invalid-password-protected.docx"  |
+      | "appeal-statement-invalid-password-protected.pdf"   |
+
+  Scenario Outline: Invalid appeal statement file with sensitive information
+    Given I have an appeal statement file <filename> "with" sensitive information
+    When I submit the appeal statement file
+    Then I can see that the file <filename> "is not" submitted
+    And I am informed why the file is not submitted
+    Examples:
+      | filename                                  |
+      | "appeal-statement-invalid-wrong-type.csv" |
+

--- a/e2e-tests/cypress/integration/appeal-statement-submission.feature
+++ b/e2e-tests/cypress/integration/appeal-statement-submission.feature
@@ -6,9 +6,8 @@ Feature: Appeal statement file submission
   The latest uploaded appeal statement file replaces any previously uploaded files.
   Appeal statements files that contain sensitive information are not permitted.
   Valid appeal statement files must:
-  * be one of the white-listed types i.e. doc, docx, pdf, tif, tiff, jpg, jpeg and png,
-  * not exceed a size limit and
-  * not be password-protected if doc, docx or pdf.
+  * be one of the white-listed types (doc, docx, pdf, tif, tiff, jpg, jpeg and png) and
+  * not exceed a size limit.
 
   Scenario Outline: Valid appeal statement file without sensitive information
     Given I have an appeal statement file <filename> "without" sensitive information
@@ -62,9 +61,6 @@ Feature: Appeal statement file submission
       | filename                                            |
       | "appeal-statement-invalid-wrong-type.csv"           |
       | "appeal-statement-invalid-exceeds-maximum-size.pdf" |
-      | "appeal-statement-invalid-password-protected.doc"   |
-      | "appeal-statement-invalid-password-protected.docx"  |
-      | "appeal-statement-invalid-password-protected.pdf"   |
 
   Scenario Outline: Invalid appeal statement file with sensitive information
     Given I have an appeal statement file <filename> "with" sensitive information

--- a/e2e-tests/cypress/integration/appeal-statement-submission/appeal-statement-submission.js
+++ b/e2e-tests/cypress/integration/appeal-statement-submission/appeal-statement-submission.js
@@ -1,0 +1,33 @@
+// These steps are merely placeholders while the approach and structure is agreed in the team.
+// They are not called in CI because the feature file is tagged as @wip.
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+
+Given('I have an appeal statement file {string} {string} sensitive information', (filename, info) => {
+  cy.log('I have an appeal statement file {string} {string} sensitive information');
+  cy.log(filename);
+  cy.log(info);
+  cy.visit('/');
+});
+
+When('I submit the appeal statement file', () => {
+  cy.log('I submit the appeal statement file');
+  cy.visit('/');
+});
+
+Then('I can see that the file {string} {string} submitted', (filename, submitted) => {
+  cy.log('I can see that the file {string} {string} submitted');
+  cy.log(filename);
+  cy.log(submitted);
+  cy.visit('/');
+});
+
+Then('I am informed why the file is not submitted', () => {
+  cy.log('I am informed why the file is not submitted');
+  cy.visit('/');
+});
+
+And('I have previously submitted an appeal statement file {string}', (filename) => {
+  cy.log(filename);
+  cy.log('I have previously submitted an appeal statement file');
+  cy.visit('/');
+});

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test:e2e": "cypress run",
+    "test:e2e": "cypress run -e TAGS='not @wip'",
     "test:e2e:postprocess": "node ./reporter.js"
   },
   "author": "",


### PR DESCRIPTION
Added feature file for appeal statement submission and introduced tags so that tests marked with
@wip will be excluded from CI. Placeholder step definitions have been included to assist with
evolution of ways of working.

## Ticket Number
UCD-988

## Description of change
Added feature file for appeal statement submission and updated CI pipeline test stage to exclude tests tagged with @wip.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [x] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
