### PR TITLE
Fix/fwa upload temp dir

### DIFF
--- a/charts/app/templates/formsWebApp.yaml
+++ b/charts/app/templates/formsWebApp.yaml
@@ -48,8 +48,6 @@ spec:
           env:
             - name: APPEALS_SERVICE_API_URL
               value: "http://{{ include "app.fullname" . }}:{{ .Values.appealsServiceApi.service.port }}"
-            - name: FILE_UPLOAD_ABORT_ON_HITTING_FILE_SIZE_LIMIT
-              value: {{ .Values.formsWebApp.config.upload.abortOnExceedSizeLimit | quote }}
             - name: FILE_UPLOAD_DEBUG
               value: {{ .Values.formsWebApp.config.upload.debug | quote }}
             - name: FILE_UPLOAD_MAX_FILE_SIZE_BYTES

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -40,7 +40,6 @@ formsWebApp:
   config:
     port: 3000
     upload:
-      abortOnExceedSizeLimit: true
       debug: true
       uploadDir: /upload-dir
       useTmpFiles: true

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -41,7 +41,7 @@ formsWebApp:
     port: 3000
     upload:
       abortOnExceedSizeLimit: true
-      debug: false
+      debug: true
       uploadDir: /upload-dir
       useTmpFiles: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,6 @@ services:
     environment:
       APPEALS_SERVICE_API_URL: http://appeals-service-api:3000
       DOCUMENT_SERVICE_API_URL: http://document-service-api:3000
-      FILE_UPLOAD_ABORT_ON_HITTING_FILE_SIZE_LIMIT: "true"
       FILE_UPLOAD_DEBUG: "false"
       FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 1262485504
       FILE_UPLOAD_USE_TEMP_FILES: "true"

--- a/forms-web-app/src/config.js
+++ b/forms-web-app/src/config.js
@@ -6,8 +6,10 @@ module.exports = {
   fileUpload: {
     abortOnLimit: process.env.FILE_UPLOAD_ABORT_ON_HITTING_FILE_SIZE_LIMIT === 'true',
     debug: process.env.FILE_UPLOAD_DEBUG === 'true',
-    // default: 1024 * 1024 * 1024 = 1gb
-    maxFileSizeBytes: Number(process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES || 1024 * 1024 * 1024),
+    limits: {
+      // default: 1024 * 1024 * 1024 = 1gb
+      fileSize: Number(process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES || 1024 * 1024 * 1024),
+    },
     tempFileDir: process.env.FILE_UPLOAD_TMP_PATH,
     useTempFiles: process.env.FILE_UPLOAD_USE_TEMP_FILES === 'true',
   },

--- a/forms-web-app/src/config.js
+++ b/forms-web-app/src/config.js
@@ -4,11 +4,11 @@ module.exports = {
     url: process.env.APPEALS_SERVICE_API_URL,
   },
   fileUpload: {
-    abortOnLimit: process.env.FILE_UPLOAD_ABORT_ON_HITTING_FILE_SIZE_LIMIT === 'true',
     debug: process.env.FILE_UPLOAD_DEBUG === 'true',
-    limits: {
-      // default: 1024 * 1024 * 1024 = 1gb
-      fileSize: Number(process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES || 1024 * 1024 * 1024),
+    pins: {
+      appealStatementMaxFileSize: Number(
+        process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES || 1024 * 1024 * 1024
+      ),
     },
     tempFileDir: process.env.FILE_UPLOAD_TMP_PATH,
     useTempFiles: process.env.FILE_UPLOAD_USE_TEMP_FILES === 'true',

--- a/forms-web-app/src/config.js
+++ b/forms-web-app/src/config.js
@@ -8,7 +8,7 @@ module.exports = {
     debug: process.env.FILE_UPLOAD_DEBUG === 'true',
     // default: 1024 * 1024 * 1024 = 1gb
     maxFileSizeBytes: Number(process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES || 1024 * 1024 * 1024),
-    tmpDir: process.env.FILE_UPLOAD_TMP_PATH,
+    tempFileDir: process.env.FILE_UPLOAD_TMP_PATH,
     useTempFiles: process.env.FILE_UPLOAD_USE_TEMP_FILES === 'true',
   },
   logger: {

--- a/forms-web-app/src/validators/appellant-submission/appeal-statement-schema.js
+++ b/forms-web-app/src/validators/appellant-submission/appeal-statement-schema.js
@@ -34,7 +34,7 @@ module.exports = {
           'Doc is the wrong file type: The file must be a DOC, DOCX, PDF, TIF, JPG or PNG'
         );
 
-        validateFileSize(size, config.fileUpload.maxFileSizeBytes);
+        validateFileSize(size, config.fileUpload.pins.appealStatementMaxFileSize);
 
         return true;
       },

--- a/forms-web-app/tests/unit/validators/appellant-submission/appeal-statement-schema.test.js
+++ b/forms-web-app/tests/unit/validators/appellant-submission/appeal-statement-schema.test.js
@@ -62,7 +62,10 @@ describe('routes/validators/appellant-submission/appeal-statement-schema', () =>
         req: { files: { a: { mimetype: MIME_TYPE_PDF, size: 12345 } } },
         path: 'a',
       });
-      expect(validateFileSize).toHaveBeenCalledWith(12345, config.fileUpload.maxFileSizeBytes);
+      expect(validateFileSize).toHaveBeenCalledWith(
+        12345,
+        config.fileUpload.pins.appealStatementMaxFileSize
+      );
     });
   });
 });

--- a/forms-web-app/tests/unit/validators/appellant-submission/appeal-statement.test.js
+++ b/forms-web-app/tests/unit/validators/appellant-submission/appeal-statement.test.js
@@ -135,7 +135,7 @@ describe('routes/validators/appellant-submission/appeal-statement', () => {
           files: {
             'appeal-statement': {
               mimetype: MIME_TYPE_JPEG,
-              size: config.fileUpload.maxFileSizeBytes + 1,
+              size: config.fileUpload.pins.appealStatementMaxFileSize + 1,
             },
           },
         }),


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-984

## Description of change
<!-- Please describe the change -->
Update the `express-fileupload` [config](https://www.npmjs.com/package/express-fileupload)
 - update `tmpDir`
 - update `limits.fileSize`
 - set Helm/k8s to debug uploads by default (future piece to investigate changing internal `console.log` to using pino)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
