### PR TITLE
test: eligibility tests re listed building and local planning dept

### DIFF
--- a/e2e-tests/cypress/integration/eligibility-listed-building-status.feature
+++ b/e2e-tests/cypress/integration/eligibility-listed-building-status.feature
@@ -1,0 +1,15 @@
+Feature: A prospective appellant states whether or not their appeal covers a listed building
+    Our service doesn't cover listed buildings.
+
+  Scenario: Listed Building statement is required
+    When the user does not provide a Listed Building statement
+    Then the user is informed that a Listed Building statement is required
+
+  Scenario: User selects yes option in the Is your appeal about a listed building page
+    When the user states that their case concerns a Listed Building
+    Then the user is informed that cases concerning a Listed Building cannot be processed via this service
+    And the user is directed to the Appeal a Planning Decision service
+
+  Scenario: User selects no option in the Is your appeal about a listed building page
+    When the user states that their case does not concern a Listed Building
+    Then the user can proceed with a non-Listed Building

--- a/e2e-tests/cypress/integration/eligibility-listed-building-status/eligibility-listed-building-status.js
+++ b/e2e-tests/cypress/integration/eligibility-listed-building-status/eligibility-listed-building-status.js
@@ -1,0 +1,30 @@
+import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
+
+When('the user does not provide a Listed Building statement', () => {
+  cy.provideNoListedBuildingStatement();
+});
+
+Then('the user is informed that a Listed Building statement is required', () => {
+  cy.confirmListedBuildingStatementIsRequired();
+});
+
+
+When('the user states that their case concerns a Listed Building', () => {
+  cy.stateCaseInvolvesListedBuilding();
+});
+
+Then('the user is informed that cases concerning a Listed Building cannot be processed via this service', () => {
+  cy.confirmListedBuildingsCannotProceed();
+});
+
+Then('the user is directed to the Appeal a Planning Decision service', () => {
+  cy.confirmRedirectToExternalService();
+});
+
+When('the user states that their case does not concern a Listed Building', () => {
+  cy.stateCaseDoesNotInvolveAListedBuilding();
+});
+
+Then('the user can proceed with a non-Listed Building', () => {
+  cy.confirmUserCanProceedWithNonListedBuilding();
+});

--- a/e2e-tests/cypress/integration/eligibility-local-planning-department.feature
+++ b/e2e-tests/cypress/integration/eligibility-local-planning-department.feature
@@ -1,0 +1,15 @@
+Feature: A prospective appellant supplies a Local Planning Department for the case they wish to appeal
+    Not every LPA is taking part in this iteration of the service.
+
+  Scenario: Local Planning Department is required
+    When the user does not provide a Local Planning Department
+    Then the user is informed that a Local Planning Department is required
+
+  Scenario: Some Local Planning Departments are not participating in this service
+    When the user provides a Local Planning Department that is not participating in this service
+    Then the user is informed that the selected Local Planning Department is not participating in the service
+    And the user is directed to the Appeal a Planning Decision service
+
+  Scenario: Local Planning Department is successfully provided
+    When the user provides a Local Planning Department that is participating in this service
+    Then the user can proceed with the provided Local Planning Department

--- a/e2e-tests/cypress/integration/eligibility-local-planning-department/eligibility-local-planning-department.js
+++ b/e2e-tests/cypress/integration/eligibility-local-planning-department/eligibility-local-planning-department.js
@@ -1,0 +1,30 @@
+import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
+
+When('the user does not provide a Local Planning Department', () => {
+  cy.provideLocalPlanningDepartment('');
+});
+
+Then('the user is informed that a Local Planning Department is required', () => {
+  cy.confirmLocalPlanningDepartmentIsRequired();
+});
+
+
+When('the user provides a Local Planning Department that is not participating in this service', () => {
+  cy.provideLocalPlanningDepartment('Anything. Whatever you want to type.');
+});
+
+Then('the user is informed that the selected Local Planning Department is not participating in the service', () => {
+  cy.confirmLocalPlanningDepartmentIsNotParticipating();
+});
+
+Then('the user is directed to the Appeal a Planning Decision service', () => {
+  cy.confirmRedirectToExternalService();
+});
+
+When('the user provides a Local Planning Department that is participating in this service', () => {
+  cy.provideLocalPlanningDepartment('Adur LPA');
+});
+
+Then('the user can proceed with the provided Local Planning Department', () => {
+  cy.confirmProviedLocalPlanningDepartmentWasAccepted();
+});

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -36,3 +36,49 @@ Cypress.Commands.add(
   'confirmUploadWasRejected',
   require('./appellant-submission-appeal-statement/confirmUploadWasRejected'),
 );
+
+Cypress.Commands.add(
+  'provideLocalPlanningDepartment',
+  require('./eligibility-local-planning-department/provideLocalPlanningDepartment'),
+);
+Cypress.Commands.add(
+  'confirmLocalPlanningDepartmentIsRequired',
+  require('./eligibility-local-planning-department/confirmLocalPlanningDepartmentIsRequired'),
+);
+Cypress.Commands.add(
+  'confirmLocalPlanningDepartmentIsNotParticipating',
+  require('./eligibility-local-planning-department/confirmLocalPlanningDepartmentIsNotParticipating'),
+);
+Cypress.Commands.add(
+  'confirmRedirectToExternalService',
+  require('./eligibility-local-planning-department/confirmRedirectToExternalService'),
+);
+Cypress.Commands.add(
+  'confirmProviedLocalPlanningDepartmentWasAccepted',
+  require('./eligibility-local-planning-department/confirmProviedLocalPlanningDepartmentWasAccepted'),
+);
+
+Cypress.Commands.add(
+  'provideNoListedBuildingStatement',
+  require('./eligibility-listed-building-status/provideNoListedBuildingStatement'),
+);
+Cypress.Commands.add(
+  'confirmListedBuildingStatementIsRequired',
+  require('./eligibility-listed-building-status/confirmListedBuildingStatementIsRequired')
+);
+Cypress.Commands.add(
+  'stateCaseInvolvesListedBuilding',
+  require('./eligibility-listed-building-status/stateCaseInvolvesListedBuilding')
+);
+Cypress.Commands.add(
+  'confirmListedBuildingsCannotProceed',
+  require('./eligibility-listed-building-status/confirmListedBuildingsCannotProceed')
+);
+Cypress.Commands.add(
+  'stateCaseDoesNotInvolveAListedBuilding',
+  require('./eligibility-listed-building-status/stateCaseDoesNotInvolveAListedBuilding'),
+);
+Cypress.Commands.add(
+  'confirmUserCanProceedWithNonListedBuilding',
+  require('./eligibility-listed-building-status/confirmUserCanProceedWithNonListedBuilding'),
+);

--- a/e2e-tests/cypress/support/eligibility-listed-building-status/confirmListedBuildingStatementIsRequired.js
+++ b/e2e-tests/cypress/support/eligibility-listed-building-status/confirmListedBuildingStatementIsRequired.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  cy.get(".govuk-error-summary__list").invoke('text').then((text) => {
+    expect(text).to.contain("Select yes if your appeal is about a listed building");
+  });
+
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-listed-building-status/confirmListedBuildingsCannotProceed.js
+++ b/e2e-tests/cypress/support/eligibility-listed-building-status/confirmListedBuildingsCannotProceed.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  cy.get("h1").invoke('text').then((text) => {
+    expect(text).to.contain("This service is not available for listed buildings");
+  });
+
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-listed-building-status/confirmUserCanProceedWithNonListedBuilding.js
+++ b/e2e-tests/cypress/support/eligibility-listed-building-status/confirmUserCanProceedWithNonListedBuilding.js
@@ -1,0 +1,15 @@
+module.exports = () => {
+  cy.get("h1").invoke('text').then((text) => {
+    expect(text).to.contain("Your appeal statement");
+  });
+
+  cy.wait(Cypress.env('demoDelay'));
+
+  // prove that the entered data is retained during navigation
+  // -> use the provided 'back' button
+  cy.get('[data-cy="back"]').click();
+  // -> confirm the expected state of the radio-buttons
+  cy.get('#is-your-appeal-about-a-listed-building-2').should('be.checked');
+  cy.get('#is-your-appeal-about-a-listed-building').should('not.be.checked');
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-listed-building-status/provideNoListedBuildingStatement.js
+++ b/e2e-tests/cypress/support/eligibility-listed-building-status/provideNoListedBuildingStatement.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  cy.visit('/eligibility/listed-building');
+
+  cy.wait(Cypress.env('demoDelay'));
+  const continueBtn = cy.get('.govuk-button').click();
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-listed-building-status/stateCaseDoesNotInvolveAListedBuilding.js
+++ b/e2e-tests/cypress/support/eligibility-listed-building-status/stateCaseDoesNotInvolveAListedBuilding.js
@@ -1,0 +1,10 @@
+module.exports = () => {
+  cy.visit('/eligibility/listed-building');
+
+  cy.get('#is-your-appeal-about-a-listed-building-2').click()
+
+
+  cy.wait(Cypress.env('demoDelay'));
+  const continueBtn = cy.get('.govuk-button').click();
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-listed-building-status/stateCaseInvolvesListedBuilding.js
+++ b/e2e-tests/cypress/support/eligibility-listed-building-status/stateCaseInvolvesListedBuilding.js
@@ -1,0 +1,10 @@
+module.exports = () => {
+  cy.visit('/eligibility/listed-building');
+
+  cy.get('#is-your-appeal-about-a-listed-building').click()
+
+
+  cy.wait(Cypress.env('demoDelay'));
+  const continueBtn = cy.get('.govuk-button').click();
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/confirmLocalPlanningDepartmentIsNotParticipating.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/confirmLocalPlanningDepartmentIsNotParticipating.js
@@ -1,0 +1,7 @@
+module.exports = (text) => {
+  cy.get("h1").invoke('text').then((text) => {
+    expect(text).to.contain("This service is not available in your area");
+  });
+
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/confirmLocalPlanningDepartmentIsRequired.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/confirmLocalPlanningDepartmentIsRequired.js
@@ -1,0 +1,7 @@
+module.exports = (text) => {
+  cy.get(".govuk-error-summary__list").invoke('text').then((text) => {
+    expect(text).to.contain("Select the local planning department from the list");
+  });
+
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/confirmProviedLocalPlanningDepartmentWasAccepted.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/confirmProviedLocalPlanningDepartmentWasAccepted.js
@@ -1,0 +1,15 @@
+module.exports = (text) => {
+  cy.url().should('include', '/eligibility/listed-building');
+
+  // pause long enough to capture a nice video
+  cy.wait(Cypress.env('demoDelay'));
+
+  // prove that the entered data is retained during navigation
+  // -> use the provided 'back' button
+  cy.get('[data-cy="back"]').click();
+
+  // confirm that the local planning department name has been retained.
+  // TODO currently failing test; need to raise this as a defect..
+  // cy.get('input#planning-department-label').should('have.value', text)
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/confirmRedirectToExternalService.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/confirmRedirectToExternalService.js
@@ -1,0 +1,7 @@
+module.exports = (text) => {
+  cy.get('[data-cy="linkToAlternativeService"]').invoke('attr', 'href').then((href) => {
+    expect(href).to.equal("https://acp.planninginspectorate.gov.uk/myportal/default.aspx");
+  });
+
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/provideLocalPlanningDepartment.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/provideLocalPlanningDepartment.js
@@ -1,0 +1,8 @@
+module.exports = (text) => {
+  cy.visit('/eligibility/planning-department');
+  cy.get('input#planning-department-label').type(`{selectall}{backspace}${text}`);
+
+  cy.wait(Cypress.env('demoDelay'));
+  const continueBtn = cy.get('.govuk-button').click();
+  cy.wait(Cypress.env('demoDelay'));
+}

--- a/forms-web-app/src/views/eligibility/listed-out.njk
+++ b/forms-web-app/src/views/eligibility/listed-out.njk
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l">This service is not available for listed buildings</h1>
 
       <p class="govuk-body">
-        This is a new service, not available for listed buildings. You can still appeal using our <a class="govuk-link" href="https://acp.planninginspectorate.gov.uk/myportal/default.aspx">appeal a planning decision service</a>.&#8203;
+        This is a new service, not available for listed buildings. You can still appeal using our <a data-cy="linkToAlternativeService" class="govuk-link" href="https://acp.planninginspectorate.gov.uk/myportal/default.aspx">appeal a planning decision service</a>.&#8203;
       </p>
 
     </div>

--- a/forms-web-app/src/views/eligibility/planning-department-out.njk
+++ b/forms-web-app/src/views/eligibility/planning-department-out.njk
@@ -13,7 +13,7 @@
 
         This is a new service and is currently only available in Adur LPA, Telford and Wrekin LPA. </p>
 
-      <p>You can still appeal using our <a class="govuk-link" href="https://acp.planninginspectorate.gov.uk/myportal/default.aspx">appeal a planning decision service</a>.​
+      <p>You can still appeal using our <a data-cy="linkToAlternativeService" class="govuk-link" href="https://acp.planninginspectorate.gov.uk/myportal/default.aspx">appeal a planning decision service</a>.​
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Ticket Number
Tickets from sprint 2 that are already in 'done'

## Description of change
retrofitting tests for:
* local planning department eligibility
* listed building eligibility

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
