### PR TITLE
fix(security): remove http application routing from the k8s stack

### DIFF
--- a/infrastructure/environments/kubernetes.tf
+++ b/infrastructure/environments/kubernetes.tf
@@ -79,6 +79,10 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   }
 
   addon_profile {
+    http_application_routing {
+      enabled = false
+    }
+
     kube_dashboard {
       enabled = false
     }


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-872

## Description of change
<!-- Please describe the change -->
Remove HTTP app routing from K8S cluster - prevents incoming traffic bypassing the load balancer by going directly to the node IP Address. 

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [x] I have updated the documentation accordingly
- [x] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
