### PR TITLE
fix(forms-web-app): file upload HTML text now matches whatever value …

### DIFF
--- a/forms-web-app/jest.config.js
+++ b/forms-web-app/jest.config.js
@@ -9,10 +9,10 @@ module.exports = {
   coverageReporters: ['json', 'html', 'text', 'text-summary'],
   coverageThreshold: {
     global: {
-      branches: 90,
-      functions: 90,
-      lines: 88,
-      statements: 88,
+      branches: 94,
+      functions: 91,
+      lines: 89,
+      statements: 89,
     },
   },
 };

--- a/forms-web-app/src/app.js
+++ b/forms-web-app/src/app.js
@@ -10,6 +10,7 @@ const pinoExpress = require('express-pino-logger');
 const uuid = require('uuid');
 const fileUpload = require('express-fileupload');
 const sessionConfig = require('./lib/session');
+const fileSizeDisplayHelper = require('./lib/file-size-display-helper');
 require('express-async-errors');
 
 const config = require('./config');
@@ -80,5 +81,7 @@ const viewPaths = [
 
 const env = nunjucks.configure(viewPaths, nunjucksConfig);
 env.addFilter('date', dateFilter);
+env.addFilter('formatBytes', fileSizeDisplayHelper);
+env.addGlobal('fileSizeLimits', config.fileUpload.pins);
 
 module.exports = app;

--- a/forms-web-app/src/lib/file-size-display-helper.js
+++ b/forms-web-app/src/lib/file-size-display-helper.js
@@ -1,0 +1,7 @@
+// https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable-string/10420404
+const suffixes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+module.exports = (bytes) => {
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return (!bytes && '0 Bytes') || `${(bytes / 1024 ** i).toFixed()} ${suffixes[i]}`;
+};

--- a/forms-web-app/src/validators/custom/file-size.js
+++ b/forms-web-app/src/validators/custom/file-size.js
@@ -1,13 +1,8 @@
-// https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable-string/10420404
-const suffixes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-const getBytes = (bytes) => {
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-  return (!bytes && '0 Bytes') || `${(bytes / 1024 ** i).toFixed()} ${suffixes[i]}`;
-};
+const fileSizeDisplayHelper = require('../../lib/file-size-display-helper');
 
 module.exports = (givenFileSize, maxFileSize) => {
   if (givenFileSize > maxFileSize) {
-    throw new Error(`The file must be smaller than ${getBytes(maxFileSize)}`);
+    throw new Error(`The file must be smaller than ${fileSizeDisplayHelper(maxFileSize)}`);
   }
 
   return true;

--- a/forms-web-app/src/views/appellant-submission/appeal-statement.njk
+++ b/forms-web-app/src/views/appellant-submission/appeal-statement.njk
@@ -102,7 +102,7 @@
         </details>
 
         {{ govukInsetText({
-          text: "File size should be no more than 50MB"
+          text: "File size should be no more than " + fileSizeLimits.appealStatementMaxFileSize | formatBytes
         }) }}
 
         {% if appeal['appeal-statement'] %}

--- a/forms-web-app/src/views/appellant-submission/upload-application.njk
+++ b/forms-web-app/src/views/appellant-submission/upload-application.njk
@@ -28,7 +28,7 @@
         <p>If you do not have your original planning application form, you can find it by searching for your planning application on your local planning department's website.</p>
 
         {{ govukInsetText({
-          text: "File size should be no more than 1.21GB"
+          text: "File size should be no more than " + fileSizeLimits.uploadApplicationMaxFileSize | formatBytes
         }) }}
 
         {% if appeal['upload-application'] %}

--- a/forms-web-app/src/views/appellant-submission/upload-decision.njk
+++ b/forms-web-app/src/views/appellant-submission/upload-decision.njk
@@ -28,7 +28,7 @@
         <p>This is the letter from the local planning department telling you about the decision on your planning application.</p>
 
         {{ govukInsetText({
-          text: "File size should be no more than 50MB"
+          text: "File size should be no more than " + fileSizeLimits.uploadDecisionMaxFileSize | formatBytes
         }) }}
 
         {% if appeal['upload-decision'] %}

--- a/forms-web-app/tests/unit/lib/file-size-display-helper.test.js
+++ b/forms-web-app/tests/unit/lib/file-size-display-helper.test.js
@@ -1,0 +1,50 @@
+const fileSizeDisplayHelper = require('../../../src/lib/file-size-display-helper');
+
+describe('lib/file-size-display-helper', () => {
+  [
+    {
+      given: 0,
+      expected: '0 Bytes',
+    },
+    {
+      given: 1,
+      expected: '1 Bytes',
+    },
+    {
+      given: 1024,
+      expected: '1 KB',
+    },
+    {
+      given: 1024 ** 2,
+      expected: '1 MB',
+    },
+    {
+      given: 1024 ** 3,
+      expected: '1 GB',
+    },
+    {
+      given: 1024 ** 4,
+      expected: '1 TB',
+    },
+    {
+      given: 1024 ** 5,
+      expected: '1 PB',
+    },
+    {
+      given: 1024 ** 6,
+      expected: '1 EB',
+    },
+    {
+      given: 1024 ** 7,
+      expected: '1 ZB',
+    },
+    {
+      given: 1024 ** 8,
+      expected: '1 YB',
+    },
+  ].forEach(({ given, expected }) => {
+    it(`should display the expected file size - ${expected}`, () => {
+      expect(fileSizeDisplayHelper(given)).toBe(expected);
+    });
+  });
+});

--- a/forms-web-app/tests/unit/lib/session.test.js
+++ b/forms-web-app/tests/unit/lib/session.test.js
@@ -1,0 +1,54 @@
+const connectMongodb = require('connect-mongodb-session');
+const expressSession = require('express-session');
+const session = require('../../../src/lib/session');
+const config = require('../../../src/config');
+
+jest.mock('express-session');
+jest.mock('../../../src/lib/logger');
+
+const mockOn = jest.fn();
+
+jest.mock('connect-mongodb-session', () =>
+  jest.fn().mockImplementation(() =>
+    jest.fn().mockImplementation(() => ({
+      on: mockOn,
+    }))
+  )
+);
+
+describe('lib/session', () => {
+  it('should throw if unable to find the session secret', () => {
+    expect(() => session()).toThrow('Session secret must be set');
+  });
+
+  it('should configure the MongoDBStore with the expected config', () => {
+    config.server.sessionSecret = 'a fake session secret';
+
+    const configuredSession = session();
+
+    expect(configuredSession.cookie).toEqual({});
+    expect(configuredSession.resave).toEqual(false);
+    expect(configuredSession.saveUninitialized).toEqual(true);
+    expect(configuredSession.secret).toEqual(config.server.sessionSecret);
+    expect(configuredSession.store.on).toBeDefined();
+
+    expect(connectMongodb).toHaveBeenCalledWith(expressSession);
+    expect(mockOn.mock.calls[0][0]).toEqual('error');
+  });
+
+  it('should configure the MongoDBStore with the expected config when useSecureSessionCookie', () => {
+    config.server.sessionSecret = 'a fake session secret';
+    config.server.useSecureSessionCookie = true;
+
+    const configuredSession = session();
+
+    expect(configuredSession.cookie.secure).toEqual(true);
+    expect(configuredSession.resave).toEqual(false);
+    expect(configuredSession.saveUninitialized).toEqual(true);
+    expect(configuredSession.secret).toEqual(config.server.sessionSecret);
+    expect(configuredSession.store.on).toBeDefined();
+
+    expect(connectMongodb).toHaveBeenCalledWith(expressSession);
+    expect(mockOn.mock.calls[0][0]).toEqual('error');
+  });
+});


### PR DESCRIPTION
…is configured in config object

## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1050

## Description of change
<!-- Please describe the change -->
1.21gb text from prototype replaced with dynamic value taken from config, formatted with same function used by the validation wrapper.

Also adds test for `lib/session` to address the jest coverage issue. 

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] I have merged commits to avoid fixing things in this PR
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
