### PR TITLE
test(e2e-tests): updated tests to use 50MB file size limit for uploads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       APPEALS_SERVICE_API_URL: http://appeals-service-api:3000
       DOCUMENT_SERVICE_API_URL: http://document-service-api:3000
       FILE_UPLOAD_DEBUG: "false"
-      FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 104857600
+      FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 52428800
       FILE_UPLOAD_USE_TEMP_FILES: "true"
       FILE_UPLOAD_TMP_PATH: "/tmp"
       SESSION_MONGODB_URL: mongodb://mongodb:27017/fwa-sessions

--- a/e2e-tests/create-large-test-files.sh
+++ b/e2e-tests/create-large-test-files.sh
@@ -1,4 +1,11 @@
-dd if=/dev/zero of=cypress/fixtures/appeal-statement-valid-max-size.png bs=104857600 count=1
-dd if=/dev/zero of=cypress/fixtures/appeal-statement-invalid-too-big.png bs=104857601 count=1
-dd if=/dev/zero of=cypress/fixtures/upload-file-valid-max-size.png bs=104857600 count=1
-dd if=/dev/zero of=cypress/fixtures/upload-file-invalid-too-big.png bs=104857601 count=1
+if [[ -z "${FILE_UPLOAD_MAX_FILE_SIZE_BYTES}" ]]; then
+  MAX_SIZE=52428800
+else
+  MAX_SIZE=$FILE_UPLOAD_MAX_FILE_SIZE_BYTES
+fi
+TOO_BIG=$((MAX_SIZE+1))
+dd if=/dev/zero of=cypress/fixtures/appeal-statement-valid-max-size.png bs=$MAX_SIZE count=1
+dd if=/dev/zero of=cypress/fixtures/appeal-statement-invalid-too-big.png bs=$TOO_BIG count=1
+dd if=/dev/zero of=cypress/fixtures/upload-file-valid-max-size.png bs=$MAX_SIZE count=1
+dd if=/dev/zero of=cypress/fixtures/upload-file-invalid-too-big.png bs=$TOO_BIG count=1
+

--- a/e2e-tests/cypress/support/appeal-statement-submission/checkNoSensitiveInformation.js
+++ b/e2e-tests/cypress/support/appeal-statement-submission/checkNoSensitiveInformation.js
@@ -1,4 +1,4 @@
 module.exports = () => {
-  cy.get('#does-not-include-sensitive-information').uncheck();
+  cy.get('#does-not-include-sensitive-information').check();
   cy.wait(Cypress.env('demoDelay'));
 };

--- a/forms-web-app/src/views/appellant-submission/appeal-statement.njk
+++ b/forms-web-app/src/views/appellant-submission/appeal-statement.njk
@@ -102,7 +102,7 @@
         </details>
 
         {{ govukInsetText({
-          text: "File size should be no more than 100MB"
+          text: "File size should be no more than 50MB"
         }) }}
 
         {% if appeal['appeal-statement'] %}

--- a/forms-web-app/src/views/appellant-submission/upload-decision.njk
+++ b/forms-web-app/src/views/appellant-submission/upload-decision.njk
@@ -28,7 +28,7 @@
         <p>This is the letter from the local planning department telling you about the decision on your planning application.</p>
 
         {{ govukInsetText({
-          text: "File size should be no more than 100MB"
+          text: "File size should be no more than 50MB"
         }) }}
 
         {% if appeal['upload-decision'] %}


### PR DESCRIPTION
## Ticket Number
UCD-1107

## Description of change
test(e2e-tests): updated tests to use 50MB file size limit for uploads
This affected appeal statement and decision letter file uploads.
Also fixed typo in checking sensitive information checkbox for appeal statement.
