### PR TITLE
fix(security): allow unsafe-inline on script-src to allow the accessibleAutocomplete

### DIFF
--- a/infrastructure/k8s/nginx-ingress/configMaps/response-headers.yaml
+++ b/infrastructure/k8s/nginx-ingress/configMaps/response-headers.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: custom-response-headers
 data:
-  Content-Security-Policy: script-src 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline';
   Permissions-Policy: vibrate=(), camera=(), microphone=(), geolocation=(), autoplay=()
   Referrer-Policy: strict-origin
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1139

## Description of change
<!-- Please describe the change -->
This drops the SecurityHeaders.com down to A from A+ which is still acceptable. A future piece of work should be done to put the accessibleAutocomplete inside a JS file that can be loaded from a URL or secured in [some other way](https://content-security-policy.com/examples/allow-inline-script/)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [x] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
