### PR TITLE
chore: add the dev environment back in

### DIFF
--- a/.github/workflows/infra-environments.yml
+++ b/.github/workflows/infra-environments.yml
@@ -35,6 +35,7 @@ jobs:
       max-parallel: 5
       matrix:
         environment:
+          - dev
           - preprod
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This was removed temporarily so there was always a live environment running

## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1174

## Description of change
<!-- Please describe the change -->
Add the dev environment back into GitHub Actions

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [x] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
