### PR TITLE
ci: we should run some percentage of our e2e tests as a smoke test wh…

### DIFF
--- a/e2e-tests/cypress/integration/appellant-submission-appeal-statement.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-appeal-statement.feature
@@ -1,3 +1,4 @@
+@smoketest
 Feature: A user supplies an appeal statement
 I need to confirm that there is no sensitive data in order to save and continue.
 

--- a/e2e-tests/cypress/integration/appellant-submission-applicant-name.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-applicant-name.feature
@@ -1,3 +1,4 @@
+@smoketest
 Feature: The user gives the original appellant name
   The users needs to give the original appellant name to save and continue.
 

--- a/e2e-tests/cypress/integration/appellant-submission-who-are-you.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-who-are-you.feature
@@ -1,3 +1,4 @@
+@smoketest
 Feature: A user is asked if he or she's the original appellant
   If the user is not the original appellant, his name should be asked
 

--- a/e2e-tests/cypress/integration/appellant-submission-your-details.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-your-details.feature
@@ -1,3 +1,4 @@
+@smoketest
 Feature: A user provides their details
   The user is required to provide a valid name and email to complete an appeal.
 

--- a/e2e-tests/cypress/integration/eligibility-listed-building-status.feature
+++ b/e2e-tests/cypress/integration/eligibility-listed-building-status.feature
@@ -1,3 +1,4 @@
+@smoketest
 Feature: A prospective appellant states whether or not their appeal covers a listed building
     Our service doesn't cover listed buildings.
 

--- a/e2e-tests/cypress/integration/eligibility-local-planning-department.feature
+++ b/e2e-tests/cypress/integration/eligibility-local-planning-department.feature
@@ -1,3 +1,4 @@
+@smoketest
 Feature: A prospective appellant supplies a Local Planning Department for the case they wish to appeal
     Not every LPA is taking part in this iteration of the service.
 

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,7 +7,8 @@
     "test:e2e": "cypress run -e TAGS='not @wip'",
     "test:e2e:demo": "cypress run --headed -b chrome --env demoDelay=1000 -e TAGS='not @wip'",
     "test:e2e:postprocess": "node ./reporter.js",
-    "test:e2e:files": "./create-large-test-files.sh"
+    "test:e2e:files": "./create-large-test-files.sh",
+    "test:e2e:smoke": "cypress run -e TAGS='not @wip and @smoketest' --config video=false,baseUrl=$BASEURL"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e:demo": "cd ./e2e-tests && npm run test:e2e:demo",
     "test:e2e:postprocess": "cd ./e2e-tests && npm run test:e2e:postprocess",
     "test:e2e:files": "cd ./e2e-tests && ./create-large-test-files.sh",
+    "test:e2e:smoke": "cd ./e2e-tests && BASEURL=$BASEURL npm run test:e2e:smoke",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
…en we deploy

## Ticket Number
UCD-1191

## Description of change

`BASEURL=https://appeals-dev.planninginspectorate.gov.uk/ npm run test:e2e:smoke`

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
