### PR TITLE
chore: change forms-webapp to v2 range

### DIFF
--- a/clusters/dev/app.yml
+++ b/clusters/dev/app.yml
@@ -8,7 +8,7 @@ metadata:
     fluxcd.io/automated: "true"
     filter.fluxcd.io/appealsServiceApi: semver:^2.0
     filter.fluxcd.io/documentServiceApi: semver:^1.0
-    filter.fluxcd.io/formsWebApp: semver:^1.0
+    filter.fluxcd.io/formsWebApp: semver:^2.0
 spec:
   releaseName: app
   chart:


### PR DESCRIPTION
The forms webapp is now compatible with the appeal service api. 
Is this correct ? 