### PR TITLE
test:glue code for application number; //TODO prove via API/check-your-answers

### DIFF
--- a/e2e-tests/cypress/integration/appellant-submission-planning-application-number.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-planning-application-number.feature
@@ -1,0 +1,24 @@
+@UI-ONLY
+Feature: Appellant submits a planning application reference number so that the planning inspectorate can refer to their appeal
+
+  Scenario Outline: Prospective appellant provides a valid planning application number
+    Given the user is prompted to provide a planning application number
+    When the user provides a planning application number <valid application number>
+    Then the appeal is updated with the provided planning application number
+
+      Examples:
+          | valid application number |
+          | "P20/21076/NMA"          |
+          | "2020/1660/01/TCA"       |
+          | "118924/JO/2018"         |
+          | "P/3423/20"              |
+
+  Scenario Outline: Prospective appellant provides an invalid planning application number
+    Given the user is prompted to provide a planning application number
+    When the user provides a planning application number <invalid application number>
+    Then the user is informed that the application number is not valid because <reason>
+    And the appeal is not updated with the provided planning application number
+
+      Examples:
+          | invalid application number   | reason            |
+          | ""                           | "mandatory field" |

--- a/e2e-tests/cypress/integration/appellant-submission-planning-application-number/appellant-submission-planning-application-number.js
+++ b/e2e-tests/cypress/integration/appellant-submission-planning-application-number/appellant-submission-planning-application-number.js
@@ -1,0 +1,25 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+
+Given('the user is prompted to provide a planning application number', () => {
+    cy.promptUserToProvidePlanningApplicationNumber();
+});
+
+When('the user provides a planning application number {string}', (valid_number) => {
+  cy.providePlanningApplicationNumber(valid_number);
+});
+
+Then('the appeal is updated with the provided planning application number', () => {
+  cy.confirmPlanningApplicationNumberHasUpdated();
+});
+
+Then('the user is informed that the application number is not valid because {string}', (reason) => {
+  switch (reason) {
+    case 'mandatory field':
+      cy.confirmPlanningApplicationNumberRejectedBecause('Enter your planning application number');
+      break;
+  }
+});
+
+Then('the appeal is not updated with the provided planning application number', () => {
+  cy.confirmPlanningApplicationNumberHasNotUpdated();
+});

--- a/e2e-tests/cypress/support/appellant-submission-planning-application-number/confirmPlanningApplicationNumberHasNotUpdated.js
+++ b/e2e-tests/cypress/support/appellant-submission-planning-application-number/confirmPlanningApplicationNumberHasNotUpdated.js
@@ -1,0 +1,6 @@
+module.exports = () => {
+  //TODO validate this on the check-your-answers page once this is implemented
+  cy.url().should('include','/appellant-submission/application-number');
+
+  cy.wait(Cypress.env('demoDelay'));
+};

--- a/e2e-tests/cypress/support/appellant-submission-planning-application-number/confirmPlanningApplicationNumberHasUpdated.js
+++ b/e2e-tests/cypress/support/appellant-submission-planning-application-number/confirmPlanningApplicationNumberHasUpdated.js
@@ -1,0 +1,6 @@
+module.exports = () => {
+  //TODO validate this on the check-your-answers page once this is implemented
+  cy.url().should('include','/appellant-submission/upload-application');
+
+  cy.wait(Cypress.env('demoDelay'));
+};

--- a/e2e-tests/cypress/support/appellant-submission-planning-application-number/confirmPlanningApplicationNumberRejectedBecause.js
+++ b/e2e-tests/cypress/support/appellant-submission-planning-application-number/confirmPlanningApplicationNumberRejectedBecause.js
@@ -1,0 +1,9 @@
+module.exports = (errorMessage) => {
+  cy.get('.govuk-error-summary__list')
+    .invoke('text')
+    .then((text) => {
+      expect(text).to.contain(errorMessage);
+    });
+
+  cy.wait(Cypress.env('demoDelay'));
+};

--- a/e2e-tests/cypress/support/appellant-submission-planning-application-number/promptUserToProvidePlanningApplicationNumber.js
+++ b/e2e-tests/cypress/support/appellant-submission-planning-application-number/promptUserToProvidePlanningApplicationNumber.js
@@ -1,0 +1,5 @@
+module.exports = () => {
+  cy.visit('/appellant-submission/application-number');
+
+  cy.wait(Cypress.env('demoDelay'));
+};

--- a/e2e-tests/cypress/support/appellant-submission-planning-application-number/providePlanningApplicationNumber.js
+++ b/e2e-tests/cypress/support/appellant-submission-planning-application-number/providePlanningApplicationNumber.js
@@ -1,0 +1,10 @@
+module.exports = (planningApplicationNumber) => {
+  // provide the planningApplicationNumber
+  cy.get('[data-cy="application-number"]')
+    .type(`{selectall}{backspace}${planningApplicationNumber}`);
+
+  cy.wait(Cypress.env('demoDelay'));
+
+  cy.get('[data-cy="save-and-continue"]').click();
+  cy.wait(Cypress.env('demoDelay'));
+};

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -277,3 +277,28 @@ Cypress.Commands.add(
   'confirmAppealNotSubmitted',
   require('./appellant-confirms-ts-and-cs/confirmAppealNotSubmitted'),
 );
+
+Cypress.Commands.add(
+  'promptUserToProvidePlanningApplicationNumber',
+  require('./appellant-submission-planning-application-number/promptUserToProvidePlanningApplicationNumber'),
+);
+
+Cypress.Commands.add(
+  'providePlanningApplicationNumber',
+  require('./appellant-submission-planning-application-number/providePlanningApplicationNumber'),
+);
+
+Cypress.Commands.add(
+  'confirmPlanningApplicationNumberHasUpdated',
+  require('./appellant-submission-planning-application-number/confirmPlanningApplicationNumberHasUpdated'),
+);
+
+Cypress.Commands.add(
+  'confirmPlanningApplicationNumberHasNotUpdated',
+  require('./appellant-submission-planning-application-number/confirmPlanningApplicationNumberHasNotUpdated'),
+);
+
+Cypress.Commands.add(
+  'confirmPlanningApplicationNumberRejectedBecause',
+  require('./appellant-submission-planning-application-number/confirmPlanningApplicationNumberRejectedBecause'),
+);

--- a/forms-web-app/src/views/appellant-submission/application-number.njk
+++ b/forms-web-app/src/views/appellant-submission/application-number.njk
@@ -30,6 +30,7 @@
           },
           id: "application-number",
           name: "application-number",
+          attributes: {"data-cy": "application-number"},
           classes: "govuk-!-width-one-half",
           spellcheck: false,
           hint: {
@@ -43,7 +44,8 @@
 
         {{ govukButton({
           text: "Save and continue",
-          type: "submit"
+          type: "submit",
+          attributes: {"data-cy": "save-and-continue"}
         }) }}
 
       </form>


### PR DESCRIPTION
## Ticket Number

UCD-1041

## Description of change
glue for proving validation around planning application reference number
NB these are superficial UI tests until we have a place we can prove persistence; that is noted in the @UI-ONLY tag on the feature and as //TODOs in the relevant cypress command..

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
