### PR TITLE
fix: include the swagger docs in the dockerfile

### DIFF
--- a/appeals-service-api/Dockerfile
+++ b/appeals-service-api/Dockerfile
@@ -9,8 +9,10 @@ ENV VERSION="${VERSION}"
 ENV SERVER_PORT=3000
 # Do not rely on NODE_ENV - exists for performance reasons only
 ENV NODE_ENV=production
+ENV DOCS_API_PATH=/opt/app/api
 # This must be built locally from the common package
 COPY --from=common:latest /opt/app ../common
+ADD api api
 ADD src src
 ADD node_modules node_modules
 ADD package.json package.json

--- a/appeals-service-api/package-lock.json
+++ b/appeals-service-api/package-lock.json
@@ -7054,7 +7054,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -7258,6 +7259,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7666,7 +7668,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "configstore": {
       "version": "5.0.1",
@@ -9047,7 +9050,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.2.1",
@@ -9136,6 +9140,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -9491,6 +9496,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -11119,6 +11125,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11747,7 +11754,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -14084,15 +14092,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "yamljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
-      }
     },
     "yargs": {
       "version": "15.4.1",

--- a/appeals-service-api/package.json
+++ b/appeals-service-api/package.json
@@ -26,7 +26,7 @@
     "express": "^4.17.1",
     "express-async-errors": "^3.1.1",
     "express-pino-logger": "^5.0.0",
-    "js-yaml": "^3.14.1",
+    "js-yaml": "^3.14.0",
     "mongodb": "^3.6.3",
     "neat-csv": "^5.2.0",
     "pino": "^6.7.0",

--- a/appeals-service-api/src/__tests__/appeals.spec.js
+++ b/appeals-service-api/src/__tests__/appeals.spec.js
@@ -25,7 +25,7 @@ describe('Appeals API', () => {
     });
     db = await connection.db();
 
-    mongodb.get.mockReturnValue(connection);
+    mongodb.get.mockReturnValue(db);
   });
 
   afterAll(async () => {

--- a/appeals-service-api/src/__tests__/appeals.spec.js
+++ b/appeals-service-api/src/__tests__/appeals.spec.js
@@ -10,11 +10,7 @@ jest.mock('../db/db');
 async function createAppeal() {
   const appeal = appealDocument;
   appeal.id = uuid.v4();
-  await mongodb
-    .get()
-    .db('appeals-service-api')
-    .collection('appeals')
-    .insertOne({ _id: appeal.id, uuid: appeal.id, appeal });
+  await mongodb.get().collection('appeals').insertOne({ _id: appeal.id, uuid: appeal.id, appeal });
   return appeal;
 }
 

--- a/appeals-service-api/src/controllers/appeals.js
+++ b/appeals-service-api/src/controllers/appeals.js
@@ -13,13 +13,11 @@ module.exports = {
     try {
       await mongodb
         .get()
-        .db('appeals-service-api')
         .collection('appeals')
         .insertOne({ _id: appeal.id, uuid: appeal.id, appeal })
         .then(() => {
           mongodb
             .get()
-            .db('appeals-service-api')
             .collection('appeals')
             .findOne({ _id: appeal.id })
             .then((doc) => {
@@ -39,7 +37,6 @@ module.exports = {
     try {
       await mongodb
         .get()
-        .db('appeals-service-api')
         .collection('appeals')
         .findOne({ _id: idParam })
         .then((doc) => {
@@ -64,7 +61,6 @@ module.exports = {
     try {
       await mongodb
         .get()
-        .db('appeals-service-api')
         .collection('appeals')
         .findOne({ _id: idParam })
         .then(async (originalDoc) => {
@@ -85,7 +81,6 @@ module.exports = {
           } else {
             await mongodb
               .get()
-              .db('appeals-service-api')
               .collection('appeals')
               .updateOne({ _id: idParam }, { $set: { uuid: idParam, appeal: validatedAppealDto } })
               .then(() => {

--- a/appeals-service-api/src/db/db.js
+++ b/appeals-service-api/src/db/db.js
@@ -19,7 +19,7 @@ function connect(callback) {
 }
 
 function get() {
-  return mongodb;
+  return mongodb.db(config.db.mongodb.dbName);
 }
 
 function close() {

--- a/appeals-service-api/src/lib/config.js
+++ b/appeals-service-api/src/lib/config.js
@@ -18,12 +18,10 @@ module.exports = {
   db: {
     mongodb: {
       url: process.env.MONGODB_URL,
+      dbName: process.env.MONGODB_DB_NAME,
       opts: {
-        autoIndex: process.env.MONGODB_AUTO_INDEX === 'true',
-        dbName: process.env.MONGODB_DB_NAME,
         useNewUrlParser: true,
         useUnifiedTopology: true,
-        useCreateIndex: true,
       },
     },
   },

--- a/appeals-service-api/src/lib/config.js
+++ b/appeals-service-api/src/lib/config.js
@@ -6,6 +6,8 @@
  * values are required
  */
 
+const path = require('path');
+
 module.exports = {
   data: {
     lpa: {
@@ -23,6 +25,11 @@ module.exports = {
         useUnifiedTopology: true,
         useCreateIndex: true,
       },
+    },
+  },
+  docs: {
+    api: {
+      path: process.env.DOCS_API_PATH || path.join(__dirname, '..', '..', 'api'),
     },
   },
   logger: {

--- a/appeals-service-api/src/lib/healthchecks.js
+++ b/appeals-service-api/src/lib/healthchecks.js
@@ -7,7 +7,7 @@ const tasks = [
   {
     name: 'mongodb',
     test: async () => {
-      const { ok } = await mongodb.get().ping();
+      const { ok } = await mongodb.get().admin().ping();
 
       return ok === 1;
     },

--- a/appeals-service-api/src/routes/api-docs.js
+++ b/appeals-service-api/src/routes/api-docs.js
@@ -2,15 +2,17 @@ const express = require('express');
 const swaggerUi = require('swagger-ui-express');
 
 const fs = require('fs');
+const path = require('path');
 const yaml = require('js-yaml');
 const logger = require('../lib/logger');
+const config = require('../lib/config');
 
 const router = express.Router();
 
 let spec;
 
 try {
-  const fileContents = fs.readFileSync('/opt/app/api/openapi.yaml', 'utf8');
+  const fileContents = fs.readFileSync(path.join(config.docs.api.path, 'openapi.yaml'), 'utf8');
   spec = yaml.safeLoad(fileContents);
   logger.debug(`Loaded api spec doc`);
 } catch (err) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       LPA_DATA_PATH: /opt/app/data/lpa-list.csv
       LPA_TRIALIST_DATA_PATH: /opt/app/data/lpa-trialists.json
       MONGODB_AUTO_INDEX: "true"
-      MONGODB_URL: mongodb://mongodb:27017/appeals-service-api
+      MONGODB_DB_NAME: appeals-service-api
+      MONGODB_URL: mongodb://mongodb:27017
       SERVER_SHOW_ERRORS: "true"
       SRV_HORIZON_URL: http://mock-horizon:3000
       SRV_NOTIFY_URL: http://mock-notify:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
   appeals-service-api:
     image: node:14-alpine
     environment:
+      DOCS_API_PATH: /opt/app/api
       DOCUMENT_SERVICE_API_URL: http://document-service-api:3000
       LPA_DATA_PATH: /opt/app/data/lpa-list.csv
       LPA_TRIALIST_DATA_PATH: /opt/app/data/lpa-trialists.json


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-985

## Description of change
<!-- Please describe the change -->
 - Include the /api folder in the Dockerfile.
 - Control the location of Swagger docs via envvar
 - Put the `mongo.db()` selection inside the mongodb wrapper `.get()` method
 - Fix health checks

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
