### PR TITLE
fix(forms-web-app): add handling for API failure and template redispl…

### DIFF
--- a/forms-web-app/src/controllers/appellant-submission/appeal-statement.js
+++ b/forms-web-app/src/controllers/appellant-submission/appeal-statement.js
@@ -43,9 +43,7 @@ exports.postAppealStatement = async (req, res) => {
       res.render(VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT, {
         appeal,
         errors,
-        errorSummary: {
-          a: 'b',
-        },
+        errorSummary: [{ text: e.toString(), href: '#' }],
       });
       return;
     }

--- a/forms-web-app/src/controllers/appellant-submission/applicant-name.js
+++ b/forms-web-app/src/controllers/appellant-submission/applicant-name.js
@@ -36,12 +36,10 @@ exports.postApplicantName = async (req, res) => {
     req.session.appeal = await createOrUpdateAppeal(appeal);
   } catch (e) {
     logger.error(e);
-    res.render(VIEW.APPELLANT_SUBMISSION.YOUR_DETAILS, {
+    res.render(VIEW.APPELLANT_SUBMISSION.APPLICANT_NAME, {
       appeal,
       errors,
-      errorSummary: {
-        a: 'b',
-      },
+      errorSummary: [{ text: e.toString(), href: '#' }],
     });
     return;
   }

--- a/forms-web-app/src/controllers/appellant-submission/application-number.js
+++ b/forms-web-app/src/controllers/appellant-submission/application-number.js
@@ -39,9 +39,7 @@ exports.postApplicationNumber = async (req, res) => {
     res.render(VIEW.APPELLANT_SUBMISSION.APPLICATION_NUMBER, {
       appeal,
       errors,
-      errorSummary: {
-        a: 'b',
-      },
+      errorSummary: [{ text: e.toString(), href: '#' }],
     });
     return;
   }

--- a/forms-web-app/src/controllers/appellant-submission/site-location.js
+++ b/forms-web-app/src/controllers/appellant-submission/site-location.js
@@ -42,9 +42,7 @@ exports.postSiteLocation = async (req, res) => {
     res.render(VIEW.APPELLANT_SUBMISSION.SITE_LOCATION, {
       appeal,
       errors,
-      errorSummary: {
-        a: 'b',
-      },
+      errorSummary: [{ text: e.toString(), href: '#' }],
     });
     return;
   }

--- a/forms-web-app/src/controllers/appellant-submission/upload-application.js
+++ b/forms-web-app/src/controllers/appellant-submission/upload-application.js
@@ -41,9 +41,7 @@ exports.postUploadApplication = async (req, res) => {
     res.render(VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION, {
       appeal,
       errors,
-      errorSummary: {
-        a: 'b',
-      },
+      errorSummary: [{ text: e.toString(), href: '#' }],
     });
     return;
   }

--- a/forms-web-app/src/controllers/appellant-submission/upload-decision.js
+++ b/forms-web-app/src/controllers/appellant-submission/upload-decision.js
@@ -42,9 +42,7 @@ exports.postUploadDecision = async (req, res) => {
     res.render(VIEW.APPELLANT_SUBMISSION.UPLOAD_DECISION, {
       appeal,
       errors,
-      errorSummary: {
-        a: 'b',
-      },
+      errorSummary: [{ text: e.toString(), href: '#' }],
     });
     return;
   }

--- a/forms-web-app/src/controllers/appellant-submission/who-are-you.js
+++ b/forms-web-app/src/controllers/appellant-submission/who-are-you.js
@@ -60,9 +60,8 @@ exports.postWhoAreYou = async (req, res) => {
     res.render(VIEW.APPELLANT_SUBMISSION.WHO_ARE_YOU, {
       appeal,
       errors,
-      errorSummary: {
-        a: 'b',
-      },
+      errorSummary: [{ text: e.toString(), href: '#' }],
+      FORM_FIELD,
     });
     return;
   }

--- a/forms-web-app/src/controllers/appellant-submission/your-details.js
+++ b/forms-web-app/src/controllers/appellant-submission/your-details.js
@@ -44,9 +44,7 @@ exports.postYourDetails = async (req, res) => {
     res.render(VIEW.APPELLANT_SUBMISSION.YOUR_DETAILS, {
       appeal,
       errors,
-      errorSummary: {
-        a: 'b',
-      },
+      errorSummary: [{ text: e.toString(), href: '#' }],
     });
     return;
   }

--- a/forms-web-app/tests/unit/controllers/appellant-submission/appeal-statement.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/appeal-statement.test.js
@@ -31,7 +31,7 @@ describe('controller/appellant-submission/appeal-statement', () => {
         ...req,
         body: {
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
         files: {
           'appeal-upload': {},
@@ -42,8 +42,8 @@ describe('controller/appellant-submission/appeal-statement', () => {
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT, {
         appeal: req.session.appeal,
-        errorSummary: { a: { msg: 'There were errors here' } },
         errors: { a: 'b' },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
       });
     });
 
@@ -76,6 +76,11 @@ describe('controller/appellant-submission/appeal-statement', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(error);
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT, {
+        appeal: req.session.appeal,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
     });
 
     it('should redirect to `/appellant-submission/supporting-documents` if valid', async () => {
@@ -99,7 +104,9 @@ describe('controller/appellant-submission/appeal-statement', () => {
       goodAppeal[sectionName][taskName].hasSensitiveInformation = false;
       goodAppeal.sectionStates[sectionName][taskName] = 'COMPLETED';
 
-      expect(res.redirect).toHaveBeenCalledWith('/appellant-submission/supporting-documents');
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/${VIEW.APPELLANT_SUBMISSION.SUPPORTING_DOCUMENTS}`
+      );
 
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(goodAppeal);
     });

--- a/forms-web-app/tests/unit/controllers/appellant-submission/applicant-name.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/applicant-name.test.js
@@ -32,7 +32,7 @@ describe('controller/appellant-submission/applicant-name', () => {
         body: {
           'behalf-appellant-name': 'Jim Jacobson',
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
       };
       await applicantNameController.postApplicantName(mockRequest, res);
@@ -43,7 +43,7 @@ describe('controller/appellant-submission/applicant-name', () => {
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.APPLICANT_NAME, {
         appeal,
-        errorSummary: { a: { msg: 'There were errors here' } },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
     });
@@ -61,6 +61,11 @@ describe('controller/appellant-submission/applicant-name', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(error);
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.APPLICANT_NAME, {
+        appeal: req.session.appeal,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
     });
 
     it('should redirect to the task list', async () => {

--- a/forms-web-app/tests/unit/controllers/appellant-submission/application-number.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/application-number.test.js
@@ -30,7 +30,7 @@ describe('controller/appellant-submission/application-number', () => {
         ...req,
         body: {
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
       };
       await applicationNumberController.postApplicationNumber(mockRequest, res);
@@ -38,7 +38,7 @@ describe('controller/appellant-submission/application-number', () => {
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.APPLICATION_NUMBER, {
         appeal: req.session.appeal,
-        errorSummary: { a: { msg: 'There were errors here' } },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
     });
@@ -54,6 +54,11 @@ describe('controller/appellant-submission/application-number', () => {
       await applicationNumberController.postApplicationNumber(mockRequest, res);
       expect(res.redirect).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(error);
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.APPLICATION_NUMBER, {
+        appeal: req.session.appeal,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
     });
 
     it('should redirect to `/appellant-submission/upload-application` if valid', async () => {

--- a/forms-web-app/tests/unit/controllers/appellant-submission/site-location.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/site-location.test.js
@@ -31,7 +31,7 @@ describe('controller/appellant-submission/site-location', () => {
         ...req,
         body: {
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
       };
       await siteLocationController.postSiteLocation(mockRequest, res);
@@ -39,7 +39,7 @@ describe('controller/appellant-submission/site-location', () => {
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.SITE_LOCATION, {
         appeal: req.session.appeal,
-        errorSummary: { a: { msg: 'There were errors here' } },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
     });
@@ -55,6 +55,11 @@ describe('controller/appellant-submission/site-location', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(error);
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.SITE_LOCATION, {
+        appeal: req.session.appeal,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
     });
 
     it('should redirect to `/appellant-submission/site-ownership` if valid', async () => {

--- a/forms-web-app/tests/unit/controllers/appellant-submission/upload-application.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/upload-application.test.js
@@ -3,6 +3,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const logger = require('../../../../src/lib/logger');
 const { EMPTY_APPEAL } = require('../../../../src/lib/appeals-api-wrapper');
+const { VIEW } = require('../../../../src/lib/views');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/lib/logger');
@@ -18,7 +19,7 @@ describe('controller/appellant-submission/upload-application', () => {
     it('should call the correct template', () => {
       uploadApplicationController.getUploadApplication(req, res);
 
-      expect(res.render).toHaveBeenCalledWith('appellant-submission/upload-application', {
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION, {
         appeal: req.session.appeal,
       });
     });
@@ -30,7 +31,7 @@ describe('controller/appellant-submission/upload-application', () => {
         ...req,
         body: {
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
         files: {
           'application-upload': {},
@@ -39,9 +40,9 @@ describe('controller/appellant-submission/upload-application', () => {
       await uploadApplicationController.postUploadApplication(mockRequest, res);
 
       expect(res.redirect).not.toHaveBeenCalled();
-      expect(res.render).toHaveBeenCalledWith('appellant-submission/upload-application', {
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION, {
         appeal: req.session.appeal,
-        errorSummary: { a: { msg: 'There were errors here' } },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
     });
@@ -58,6 +59,11 @@ describe('controller/appellant-submission/upload-application', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(error);
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION, {
+        appeal: req.session.appeal,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
     });
 
     it('should redirect to `/appellant-submission/supporting-documents` if valid', async () => {
@@ -78,7 +84,7 @@ describe('controller/appellant-submission/upload-application', () => {
       goodAppeal[sectionName][taskName].uploadedFile = { name: 'some name.jpg' };
       goodAppeal.sectionStates[sectionName][taskName] = 'COMPLETED';
 
-      expect(res.redirect).toHaveBeenCalledWith('/appellant-submission/upload-decision');
+      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.APPELLANT_SUBMISSION.UPLOAD_DECISION}`);
 
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(goodAppeal);
     });

--- a/forms-web-app/tests/unit/controllers/appellant-submission/upload-decision.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/upload-decision.test.js
@@ -3,6 +3,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const logger = require('../../../../src/lib/logger');
 const { EMPTY_APPEAL } = require('../../../../src/lib/appeals-api-wrapper');
+const { VIEW } = require('../../../../src/lib/views');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/lib/logger');
@@ -18,7 +19,7 @@ describe('controller/appellant-submission/upload-decision', () => {
     it('should call the correct template', () => {
       uploadDecisionController.getUploadDecision(req, res);
 
-      expect(res.render).toHaveBeenCalledWith('appellant-submission/upload-decision', {
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.UPLOAD_DECISION, {
         appeal: req.session.appeal,
       });
     });
@@ -30,7 +31,7 @@ describe('controller/appellant-submission/upload-decision', () => {
         ...req,
         body: {
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
         files: {
           'decision-upload': {},
@@ -39,9 +40,9 @@ describe('controller/appellant-submission/upload-decision', () => {
       await uploadDecisionController.postUploadDecision(mockRequest, res);
 
       expect(res.redirect).not.toHaveBeenCalled();
-      expect(res.render).toHaveBeenCalledWith('appellant-submission/upload-decision', {
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.UPLOAD_DECISION, {
         appeal: req.session.appeal,
-        errorSummary: { a: { msg: 'There were errors here' } },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
     });
@@ -58,6 +59,11 @@ describe('controller/appellant-submission/upload-decision', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(error);
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.UPLOAD_DECISION, {
+        appeal: req.session.appeal,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
     });
 
     it('should redirect to `/appellant-submission/task-list` if valid', async () => {
@@ -78,7 +84,7 @@ describe('controller/appellant-submission/upload-decision', () => {
       goodAppeal[sectionName][taskName].uploadedFile = { name: 'some name.jpg' };
       goodAppeal.sectionStates[sectionName][taskName] = 'COMPLETED';
 
-      expect(res.redirect).toHaveBeenCalledWith('/appellant-submission/task-list');
+      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.APPELLANT_SUBMISSION.TASK_LIST}`);
 
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(goodAppeal);
     });

--- a/forms-web-app/tests/unit/controllers/appellant-submission/who-are-you.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/who-are-you.test.js
@@ -77,7 +77,7 @@ describe('controller/appellant-submission/who-are-you', () => {
         body: {
           'are-you-the-original-appellant': true,
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
       };
       await whoAreYouController.postWhoAreYou(mockRequest, res);
@@ -90,7 +90,7 @@ describe('controller/appellant-submission/who-are-you', () => {
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.WHO_ARE_YOU, {
         FORM_FIELD,
         appeal,
-        errorSummary: { a: { msg: 'There were errors here' } },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
     });
@@ -108,6 +108,12 @@ describe('controller/appellant-submission/who-are-you', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(error);
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.WHO_ARE_YOU, {
+        FORM_FIELD,
+        appeal: mockRequest.session.appeal,
+        errorSummary: [{ text: error.toString(), href: '#' }],
+        errors: {},
+      });
     });
   });
 });

--- a/forms-web-app/tests/unit/controllers/appellant-submission/your-details.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/your-details.test.js
@@ -31,7 +31,7 @@ describe('controller/appellant-submission/your-details', () => {
         ...req,
         body: {
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
       };
       await yourDetailsController.postYourDetails(mockRequest, res);
@@ -39,7 +39,7 @@ describe('controller/appellant-submission/your-details', () => {
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.YOUR_DETAILS, {
         appeal: req.session.appeal,
-        errorSummary: { a: { msg: 'There were errors here' } },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
     });
@@ -55,6 +55,11 @@ describe('controller/appellant-submission/your-details', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(logger.error).toHaveBeenCalledWith(error);
+      expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.YOUR_DETAILS, {
+        appeal: req.session.appeal,
+        errorSummary: [{ text: error.toString(), href: '#' }],
+        errors: {},
+      });
     });
 
     it('should redirect to task list if valid and original appellant', async () => {

--- a/forms-web-app/tests/unit/controllers/submission.test.js
+++ b/forms-web-app/tests/unit/controllers/submission.test.js
@@ -20,14 +20,14 @@ describe('controller/submission', () => {
         ...req,
         body: {
           errors: { a: 'b' },
-          errorSummary: { a: { msg: 'There were errors here' } },
+          errorSummary: [{ text: 'There were errors here', href: '#' }],
         },
       };
       await submissionController.postSubmission(mockRequest, res);
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.SUBMISSION, {
-        errorSummary: { a: { msg: 'There were errors here' } },
+        errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
     });


### PR DESCRIPTION
…ay with error summary

## Ticket Number
<!-- Add the number from the Jira board -->
UCD-887

## Description of change
<!-- Please describe the change -->
Display the error message returned from an API failure on the page error summary.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] I have merged commits to avoid fixing things in this PR
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
