### PR TITLE
feat(forms-web-app): integrate FWA to Appeals API for Appeal Statemen…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ install:
 
 	for dir in ${APPS}; do \
 		(cd $${dir} && npm ci); \
+		if [ $${dir} == 'e2e-tests' ]; then \
+			(cd $${dir} && ./create-large-test-files.sh); \
+		fi \
   	done
 .PHONY: install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: node:14-alpine
     environment:
       DOCS_API_PATH: /opt/app/api
-      DOCUMENT_SERVICE_API_URL: http://document-service-api:3000
+      DOCUMENTS_SERVICE_API_URL: http://document-service-api:3000
       LPA_DATA_PATH: /opt/app/data/lpa-list.csv
       LPA_TRIALIST_DATA_PATH: /opt/app/data/lpa-trialists.json
       MONGODB_AUTO_INDEX: "true"
@@ -83,7 +83,7 @@ services:
     image: node:14-alpine
     environment:
       APPEALS_SERVICE_API_URL: http://appeals-service-api:3000
-      DOCUMENT_SERVICE_API_URL: http://document-service-api:3000
+      DOCUMENTS_SERVICE_API_URL: http://document-service-api:3000
       FILE_UPLOAD_DEBUG: "false"
       FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 52428800
       FILE_UPLOAD_USE_TEMP_FILES: "true"

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -14,12 +14,15 @@ the default. However, when producing video artefacts intended to be presented it
 of waiting or pausing during the test execution. Environment variables can be used for this configuration and one 
 named `demoDelay` is provided in the `cypress.json` file. The variable can be used in statements 
 like `cy.wait(Cypress.env('demoDelay'))` to control wait times i.e. the value is the required delay in milliseconds.
-From the `e2e-tests` folder, the tests can be run locally setting the delay period with commands like:
+From the `e2e-tests` folder, the tests can be run locally setting the delay period with commands like this for 
+selection of tests by tags i.e. only those with `@wip` tag:
 ```
 node_modules/cypress/bin/cypress run --headed -b chrome --env demoDelay=1000 -e TAGS="@wip"
 ```
-
-Note: In the example above only tests tagged with `@wip` will be selected to run.
+or like this to select a specific feature file:
+```
+node_modules/cypress/bin/cypress run --headed -b chrome --env demoDelay=1000 --spec cypress/integration/appeal-statement-submission.feature
+```
 
 #### Test data
 

--- a/e2e-tests/create-large-test-files.sh
+++ b/e2e-tests/create-large-test-files.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 if [[ -z "${FILE_UPLOAD_MAX_FILE_SIZE_BYTES}" ]]; then
   MAX_SIZE=52428800
 else
@@ -8,4 +10,3 @@ dd if=/dev/zero of=cypress/fixtures/appeal-statement-valid-max-size.png bs=$MAX_
 dd if=/dev/zero of=cypress/fixtures/appeal-statement-invalid-too-big.png bs=$TOO_BIG count=1
 dd if=/dev/zero of=cypress/fixtures/upload-file-valid-max-size.png bs=$MAX_SIZE count=1
 dd if=/dev/zero of=cypress/fixtures/upload-file-invalid-too-big.png bs=$TOO_BIG count=1
-

--- a/e2e-tests/cypress/integration/appeal-statement-submission.feature
+++ b/e2e-tests/cypress/integration/appeal-statement-submission.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Appeal statement file submission
 
   I want to submit an appeal statement.
@@ -8,6 +7,10 @@ Feature: Appeal statement file submission
   * not exceed a size limit.
   Appeal statements files that contain sensitive information are not permitted.
   The latest successfully uploaded appeal statement file replaces any previously uploaded file.
+
+  Scenario: Prospective applicant confirms no sensitive information but chooses not to upload an appeal statement file
+    When user confirms that there is no sensitive information without selecting an appeal statement file to upload
+    Then user can see that no appeal statement file is submitted
 
   Scenario Outline: Prospective appellant submits valid appeal statement file without sensitive information
     When user submits an appeal statement file <filename> confirming that it "does not" contain sensitive information

--- a/e2e-tests/cypress/integration/appeal-statement-submission/appeal-statement-submission.js
+++ b/e2e-tests/cypress/integration/appeal-statement-submission/appeal-statement-submission.js
@@ -1,9 +1,15 @@
-import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import {Given, When, Then} from 'cypress-cucumber-preprocessor/steps';
 
 Given('user has previously submitted an appeal statement file {string}', (filename) => {
   cy.goToAppealStatementSubmission();
   cy.checkNoSensitiveInformation();
   cy.uploadAppealStatementFile(filename);
+  cy.saveAndContinue();
+});
+
+When('user confirms that there is no sensitive information without selecting an appeal statement file to upload', () => {
+  cy.goToAppealStatementSubmission();
+  cy.checkNoSensitiveInformation();
   cy.saveAndContinue();
 });
 
@@ -17,6 +23,10 @@ When('user submits an appeal statement file {string} confirming that it {string}
   cy.uploadAppealStatementFile(filename);
   cy.saveAndContinue();
 });
+
+Then('user can see that no appeal statement file is submitted', () => {
+  cy.confirmAppealStatementFileIsNotUploaded();
+})
 
 Then('user can see that the appeal statement file {string} {string} submitted', (filename, submitted) => {
   if (submitted === 'is') {

--- a/e2e-tests/cypress/integration/appellant-submission-upload-application.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-upload-application.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Planning Application file submission
 
   Scenario Outline: Prospective appellant submits valid planning application file

--- a/e2e-tests/cypress/integration/appellant-submission-upload-decision.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-upload-decision.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Upload Decision file submission
 
   Scenario Outline: Prospective appellant submits valid upload decision file

--- a/forms-web-app/jest.config.js
+++ b/forms-web-app/jest.config.js
@@ -9,10 +9,10 @@ module.exports = {
   coverageReporters: ['json', 'html', 'text', 'text-summary'],
   coverageThreshold: {
     global: {
-      branches: 93,
-      functions: 92,
-      lines: 90,
-      statements: 90,
+      branches: 94,
+      functions: 94,
+      lines: 92,
+      statements: 92,
     },
   },
 };

--- a/forms-web-app/package-lock.json
+++ b/forms-web-app/package-lock.json
@@ -9664,12 +9664,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -13946,6 +13946,16 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",

--- a/forms-web-app/package.json
+++ b/forms-web-app/package.json
@@ -35,6 +35,7 @@
     "express-session": "^1.17.1",
     "express-validator": "^6.6.1",
     "file-type": "^16.0.1",
+    "form-data": "^3.0.0",
     "govuk-frontend": "^3.9.1",
     "http-errors": "~1.6.3",
     "lusca": "^1.6.1",

--- a/forms-web-app/src/config.js
+++ b/forms-web-app/src/config.js
@@ -19,6 +19,10 @@ module.exports = {
       },
     },
   },
+  documents: {
+    timeout: Number(process.env.DOCUMENTS_SERVICE_API_TIMEOUT || 10000),
+    url: process.env.DOCUMENTS_SERVICE_API_URL,
+  },
   fileUpload: {
     debug: process.env.FILE_UPLOAD_DEBUG === 'true',
     pins: {

--- a/forms-web-app/src/controllers/appellant-submission/appeal-statement.js
+++ b/forms-web-app/src/controllers/appellant-submission/appeal-statement.js
@@ -1,5 +1,6 @@
 const { VIEW } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
+const { createDocument } = require('../../lib/documents-api-wrapper');
 const logger = require('../../lib/logger');
 const { getNextUncompletedTask } = require('../../services/task.service');
 const { getTaskStatus } = require('../../services/task.service');
@@ -19,39 +20,44 @@ exports.postAppealStatement = async (req, res) => {
 
   if (Object.keys(errors).length > 0) {
     res.render(VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT, {
-      appeal: req.session.appeal || {},
+      appeal: req.session.appeal,
       errors,
       errorSummary,
     });
     return;
   }
 
-  const { appeal } = req.session;
-  const task = appeal[sectionName][taskName];
-
-  task.uploadedFile = req.files &&
-    req.files['appeal-upload'] && {
-      name: req.files['appeal-upload'].name,
-    };
-
-  if (body['does-not-include-sensitive-information'] === 'i-confirm') {
-    try {
-      task.hasSensitiveInformation = false;
-      appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
-      req.session.appeal = await createOrUpdateAppeal(appeal);
-    } catch (e) {
-      logger.error(e);
-      res.render(VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT, {
-        appeal,
-        errors,
-        errorSummary: [{ text: e.toString(), href: '#' }],
-      });
-      return;
-    }
-
-    res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  if (body['does-not-include-sensitive-information'] !== 'i-confirm') {
+    res.redirect(`/${VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT}`);
     return;
   }
 
-  res.redirect(`/${VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT}`);
+  const { appeal } = req.session;
+
+  try {
+    appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
+    appeal.yourAppealSection.appealStatement.hasSensitiveInformation = false;
+    if ('files' in req && req.files !== null) {
+      if ('appeal-upload' in req.files) {
+        const document = await createDocument(appeal, req.files['appeal-upload']);
+
+        appeal[sectionName][taskName].uploadedFile = {
+          id: document.id,
+          name: req.files['appeal-upload'].name,
+        };
+      }
+    }
+
+    req.session.appeal = await createOrUpdateAppeal(appeal);
+  } catch (e) {
+    logger.error(e);
+    res.render(VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT, {
+      appeal,
+      errors,
+      errorSummary: [{ text: e.toString(), href: '#' }],
+    });
+    return;
+  }
+
+  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
 };

--- a/forms-web-app/src/lib/appeals-api-wrapper.js
+++ b/forms-web-app/src/lib/appeals-api-wrapper.js
@@ -34,7 +34,7 @@ async function handler(path, method = 'GET', opts = {}, headers = {}) {
           logger.debug(apiResponse, 'API Response not OK');
           try {
             const errorResponse = await apiResponse.json();
-            if (errorResponse.errors.length) {
+            if (errorResponse.errors && errorResponse.errors.length) {
               throw new Error(errorResponse.errors.join('\n'));
             }
 

--- a/forms-web-app/src/lib/documents-api-wrapper.js
+++ b/forms-web-app/src/lib/documents-api-wrapper.js
@@ -1,0 +1,48 @@
+const fetch = require('node-fetch');
+const FormData = require('form-data');
+const uuid = require('uuid');
+
+const config = require('../config');
+const parentLogger = require('./logger');
+
+exports.createDocument = async (appeal, formData) => {
+  const path = `/api/v1/${appeal.id}`;
+
+  const correlationId = uuid.v4();
+  const url = `${config.documents.url}${path}`;
+
+  const logger = parentLogger.child({
+    correlationId,
+    service: 'Document Service API',
+  });
+
+  let apiResponse;
+  try {
+    const fd = new FormData();
+    fd.append('file', Buffer.from(formData.data), formData.name);
+
+    apiResponse = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'X-Correlation-ID': correlationId,
+      },
+      body: fd,
+    });
+  } catch (e) {
+    logger.error(e);
+    throw new Error(e.toString());
+  }
+
+  if (!apiResponse.ok) {
+    logger.debug(apiResponse, 'Documents API Response not OK');
+    throw new Error(apiResponse.statusText);
+  }
+
+  const ok = (await apiResponse.status) === 202;
+
+  if (!ok) {
+    throw new Error(apiResponse.statusText);
+  }
+
+  return apiResponse.json();
+};

--- a/forms-web-app/src/middleware/fetch-existing-appeal.js
+++ b/forms-web-app/src/middleware/fetch-existing-appeal.js
@@ -1,6 +1,4 @@
-const { APPEAL_DOCUMENT } = require('../lib/empty-appeal');
-
-const { getExistingAppeal } = require('../lib/appeals-api-wrapper');
+const { createOrUpdateAppeal, getExistingAppeal } = require('../lib/appeals-api-wrapper');
 
 /**
  * Middleware to ensure any route that needs the appeal form data can have it pre-populated when the
@@ -17,7 +15,7 @@ module.exports = async (req, res, next) => {
   }
 
   if (!req.session.appeal || !req.session.appeal.id) {
-    req.session.appeal = APPEAL_DOCUMENT.empty;
+    req.session.appeal = await createOrUpdateAppeal({});
     return next();
   }
 
@@ -26,7 +24,7 @@ module.exports = async (req, res, next) => {
     req.session.appeal = await getExistingAppeal(req.session.appeal.id);
   } catch (err) {
     req.log.debug({ err }, 'Error retrieving appeal');
-    req.session.appeal = APPEAL_DOCUMENT.empty;
+    req.session.appeal = await createOrUpdateAppeal({});
   }
   return next();
 };

--- a/forms-web-app/src/services/task.service.js
+++ b/forms-web-app/src/services/task.service.js
@@ -29,7 +29,7 @@ function statusYourDetails(appeal) {
 
 function statusAppealStatement(appeal) {
   const task = appeal.yourAppealSection.appealStatement;
-  return task.uploadedFile.name ? TASK_STATUS.COMPLETED : TASK_STATUS.NOT_STARTED;
+  return task.hasSensitiveInformation === false ? TASK_STATUS.COMPLETED : TASK_STATUS.NOT_STARTED;
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/forms-web-app/src/validators/appellant-submission/application-number.js
+++ b/forms-web-app/src/validators/appellant-submission/application-number.js
@@ -1,10 +1,7 @@
 const { body } = require('express-validator');
 
 const rulePlanningApplicationNumber = () =>
-  body('application-number')
-    .escape()
-    .notEmpty()
-    .withMessage('Enter your planning application number');
+  body('application-number').notEmpty().withMessage('Enter your planning application number');
 
 const rules = () => {
   return [rulePlanningApplicationNumber()];

--- a/forms-web-app/src/views/appellant-submission/appeal-statement.njk
+++ b/forms-web-app/src/views/appellant-submission/appeal-statement.njk
@@ -147,6 +147,7 @@
           name: "does-not-include-sensitive-information",
           items: [
             {
+              checked: (appeal.yourAppealSection.appealStatement.hasSensitiveInformation === false),
               value: "i-confirm",
               text: "I confirm that I have not included sensitive information in my appeal statement."
             }

--- a/forms-web-app/tests/unit/controllers/appellant-submission/appeal-statement.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/appeal-statement.test.js
@@ -1,17 +1,19 @@
 const appealStatementController = require('../../../../src/controllers/appellant-submission/appeal-statement');
-const { mockReq, mockRes } = require('../../mocks');
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
-const { getNextUncompletedTask } = require('../../../../src/services/task.service');
+const { createDocument } = require('../../../../src/lib/documents-api-wrapper');
+const { mockReq, mockRes } = require('../../mocks');
+
 const logger = require('../../../../src/lib/logger');
+const { getNextUncompletedTask } = require('../../../../src/services/task.service');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 
 const { VIEW } = require('../../../../src/lib/views');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../../src/lib/documents-api-wrapper');
 jest.mock('../../../../src/services/task.service');
 jest.mock('../../../../src/lib/logger');
 
-const req = mockReq();
 const res = mockRes();
 
 const sectionName = 'yourAppealSection';
@@ -19,8 +21,9 @@ const taskName = 'appealStatement';
 
 describe('controller/appellant-submission/appeal-statement', () => {
   describe('getAppealStatement', () => {
-    it('should call the correct template', () => {
-      appealStatementController.getAppealStatement(req, res);
+    it('should call the correct template', async () => {
+      const req = mockReq();
+      await appealStatementController.getAppealStatement(req, res);
 
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.APPEAL_STATEMENT, {
         appeal: req.session.appeal,
@@ -30,14 +33,12 @@ describe('controller/appellant-submission/appeal-statement', () => {
 
   describe('postAppealStatement', () => {
     it('should re-render the template with errors if submission validation fails', async () => {
+      const req = mockReq();
       const mockRequest = {
         ...req,
         body: {
           errors: { a: 'b' },
           errorSummary: [{ text: 'There were errors here', href: '#' }],
-        },
-        files: {
-          'appeal-upload': {},
         },
       };
       await appealStatementController.postAppealStatement(mockRequest, res);
@@ -51,6 +52,7 @@ describe('controller/appellant-submission/appeal-statement', () => {
     });
 
     it('should redirect back to `/appellant-submission/appeal-statement` if validation passes but `i-confirm` not given', async () => {
+      const req = mockReq();
       const mockRequest = {
         ...req,
         body: {
@@ -60,12 +62,13 @@ describe('controller/appellant-submission/appeal-statement', () => {
           'appeal-upload': {},
         },
       };
-      appealStatementController.postAppealStatement(mockRequest, res);
+      await appealStatementController.postAppealStatement(mockRequest, res);
 
       expect(res.redirect).toHaveBeenCalledWith('/appellant-submission/appeal-statement');
     });
 
     it('should log an error if the api call fails, and remain on the same page', async () => {
+      const req = mockReq();
       const error = new Error('API is down');
       createOrUpdateAppeal.mockImplementation(() => Promise.reject(error));
       const mockRequest = {
@@ -86,8 +89,38 @@ describe('controller/appellant-submission/appeal-statement', () => {
       });
     });
 
-    it('should redirect to `/appellant-submission/supporting-documents` if valid', async () => {
+    it('should not require req.files to be valid', async () => {
+      const req = mockReq();
       createOrUpdateAppeal.mockImplementation(() => JSON.stringify({ good: 'data' }));
+      getNextUncompletedTask.mockReturnValue({
+        href: `/${VIEW.APPELLANT_SUBMISSION.SUPPORTING_DOCUMENTS}`,
+      });
+
+      const mockRequest = {
+        ...req,
+        body: {
+          'does-not-include-sensitive-information': 'i-confirm',
+        },
+      };
+      await appealStatementController.postAppealStatement(mockRequest, res);
+
+      const { empty: goodAppeal } = APPEAL_DOCUMENT;
+      goodAppeal[sectionName][taskName].uploadedFile = { name: 'some name.jpg' };
+      goodAppeal[sectionName][taskName].hasSensitiveInformation = false;
+      goodAppeal.sectionStates[sectionName][taskName] = 'COMPLETED';
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/${VIEW.APPELLANT_SUBMISSION.SUPPORTING_DOCUMENTS}`
+      );
+
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(goodAppeal);
+      expect(createDocument).not.toHaveBeenCalled();
+    });
+
+    it('should redirect to `/appellant-submission/supporting-documents` if valid', async () => {
+      const req = mockReq();
+      createOrUpdateAppeal.mockImplementation(() => JSON.stringify({ good: 'data' }));
+      createDocument.mockImplementation(() => JSON.stringify({ id: '123-abc' }));
       getNextUncompletedTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.SUPPORTING_DOCUMENTS}`,
       });
@@ -115,6 +148,7 @@ describe('controller/appellant-submission/appeal-statement', () => {
       );
 
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(goodAppeal);
+      expect(createDocument).toHaveBeenCalledWith(goodAppeal, { name: 'some name.jpg' });
     });
   });
 });

--- a/forms-web-app/tests/unit/controllers/appellant-submission/task-list.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/task-list.test.js
@@ -179,9 +179,7 @@ describe('controller/appellant-submission/task-list', () => {
         },
         yourAppealSection: {
           appealStatement: {
-            uploadedFile: {
-              name: 'appeal.pdf',
-            },
+            hasSensitiveInformation: false,
           },
         },
       });
@@ -359,9 +357,7 @@ describe('controller/appellant-submission/task-list', () => {
         },
         yourAppealSection: {
           appealStatement: {
-            uploadedFile: {
-              name: 'appeal.pdf',
-            },
+            hasSensitiveInformation: false,
           },
         },
       });

--- a/forms-web-app/tests/unit/lib/documents-api-wrapper.test.js
+++ b/forms-web-app/tests/unit/lib/documents-api-wrapper.test.js
@@ -1,0 +1,66 @@
+const fetch = require('node-fetch');
+const { createDocument } = require('../../../src/lib/documents-api-wrapper');
+
+const mockLogger = jest.fn();
+
+jest.mock('../../../src/lib/logger', () => ({
+  child: () => ({
+    debug: mockLogger,
+    error: mockLogger,
+    warn: mockLogger,
+  }),
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => '123-abc-456-xyz'),
+}));
+
+describe('lib/documents-api-wrapper', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  describe('createDocument', () => {
+    let mockAppeal;
+    let formData;
+
+    beforeEach(() => {
+      mockAppeal = { id: 123 };
+      formData = {
+        // eslint-disable-next-line new-cap
+        data: new Buffer.from('dummy buffer'),
+      };
+    });
+
+    it('should throw if fetch fails', async () => {
+      fetch.mockReject(new Error('fake error message'));
+      expect(createDocument(mockAppeal, formData)).rejects.toThrow('fake error message');
+    });
+
+    it('should throw if the remote API response is not ok', () => {
+      fetch.mockResponse('fake response body', { status: 400 });
+      expect(createDocument(mockAppeal, formData)).rejects.toThrow('Bad Request');
+    });
+
+    it('should throw if the response code is anything other than a 202', async () => {
+      fetch.mockResponse('a response body', { status: 204 });
+      expect(createDocument(mockAppeal, formData)).rejects.toThrow('No Content');
+    });
+
+    it('should return the expected response if the fetch status is 202', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          applicationId: 123,
+          id: '123-abc-456-xyz',
+          name: 'tmp-2-1607684291243',
+        }),
+        { status: 202 }
+      );
+      expect(await createDocument(mockAppeal, formData)).toEqual({
+        applicationId: 123,
+        id: '123-abc-456-xyz',
+        name: 'tmp-2-1607684291243',
+      });
+    });
+  });
+});

--- a/forms-web-app/tests/unit/lib/session.test.js
+++ b/forms-web-app/tests/unit/lib/session.test.js
@@ -47,6 +47,7 @@ describe('lib/session', () => {
     expect(configuredSession.saveUninitialized).toEqual(true);
     expect(configuredSession.secret).toEqual(config.server.sessionSecret);
     expect(configuredSession.store.on).toBeDefined();
+    expect(configuredSession.store.on).toHaveBeenCalledWith('error', expect.any(Function));
 
     expect(connectMongodb).toHaveBeenCalledWith(expressSession);
     expect(mockOn.mock.calls[0][0]).toEqual('error');

--- a/forms-web-app/tests/unit/middleware/fetch-existing-appeal.test.js
+++ b/forms-web-app/tests/unit/middleware/fetch-existing-appeal.test.js
@@ -2,9 +2,8 @@ jest.mock('../../../src/lib/appeals-api-wrapper');
 
 const { mockReq, mockRes } = require('../mocks');
 const fetchExistingAppealMiddleware = require('../../../src/middleware/fetch-existing-appeal');
-const { getExistingAppeal } = require('../../../src/lib/appeals-api-wrapper');
+const { createOrUpdateAppeal, getExistingAppeal } = require('../../../src/lib/appeals-api-wrapper');
 const config = require('../../../src/config');
-const { APPEAL_DOCUMENT } = require('../../../src/lib/empty-appeal');
 
 config.appeals.url = 'http://fake.url';
 
@@ -25,6 +24,7 @@ describe('middleware/fetch-existing-appeal', () => {
       }),
       expected: (req, res, next) => {
         expect(getExistingAppeal).not.toHaveBeenCalled();
+        expect(createOrUpdateAppeal).toHaveBeenCalledWith({});
         expect(next).toHaveBeenCalled();
       },
     },
@@ -42,6 +42,7 @@ describe('middleware/fetch-existing-appeal', () => {
       title: 'call next if api lookup fails',
       given: () => {
         getExistingAppeal.mockRejectedValue('API is down');
+        createOrUpdateAppeal.mockReturnValue({ fake: 'appeal data' });
         return {
           ...mockReq(),
           session: {
@@ -53,8 +54,9 @@ describe('middleware/fetch-existing-appeal', () => {
       },
       expected: (req, res, next) => {
         expect(getExistingAppeal).toHaveBeenCalledWith('123-abc');
+        expect(createOrUpdateAppeal).toHaveBeenCalledWith({});
+        expect(req.session.appeal).toEqual({ fake: 'appeal data' });
         expect(next).toHaveBeenCalled();
-        expect(req.session.appeal).toEqual(APPEAL_DOCUMENT.empty);
       },
     },
     {

--- a/forms-web-app/tests/unit/services/task.service.test.js
+++ b/forms-web-app/tests/unit/services/task.service.test.js
@@ -1,6 +1,6 @@
 const { VIEW } = require('../../../src/lib/views');
 
-const { getNextUncompletedTask } = require('../../../src/services/task.service');
+const { getNextUncompletedTask, SECTIONS } = require('../../../src/services/task.service');
 
 describe('services/task', () => {
   describe('getNextTask', () => {
@@ -49,6 +49,13 @@ describe('services/task', () => {
       );
 
       expect(task.href).toEqual(`/${VIEW.APPELLANT_SUBMISSION.TASK_LIST}`);
+    });
+  });
+  describe('SECTIONS', () => {
+    it('should return early from statusCheckYourAnswer if the appeal is already submitted ', () => {
+      expect(
+        SECTIONS.submitYourAppealSection.checkYourAnswers.rule({ state: 'SUBMITTED' })
+      ).toEqual('COMPLETED');
     });
   });
 });

--- a/forms-web-app/tests/unit/validators/appellant-submission/application-number.test.js
+++ b/forms-web-app/tests/unit/validators/appellant-submission/application-number.test.js
@@ -12,13 +12,11 @@ describe('validators/appellant-submission/application-number', () => {
       expect(rule.fields).toEqual(['application-number']);
       expect(rule.locations).toEqual(['body']);
       expect(rule.optional).toBeFalsy();
-      expect(rule.stack).toHaveLength(2);
+      expect(rule.stack).toHaveLength(1);
 
-      expect(rule.stack[0].sanitizer.name).toEqual('escape');
-
-      expect(rule.stack[1].negated).toBeTruthy();
-      expect(rule.stack[1].validator.name).toEqual('isEmpty');
-      expect(rule.stack[1].message).toEqual('Enter your planning application number');
+      expect(rule.stack[0].negated).toBeTruthy();
+      expect(rule.stack[0].validator.name).toEqual('isEmpty');
+      expect(rule.stack[0].message).toEqual('Enter your planning application number');
     });
   });
   describe('validator', () => {


### PR DESCRIPTION
…t section

Adds document service API integration

## Ticket Number
<!-- Add the number from the Jira board -->
UCD-830

## Description of change
<!-- Please describe the change -->
Adds document service API integration for appeal-statement upload

Thanks @frank-dodion 

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] I have merged commits to avoid fixing things in this PR
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
