### PR TITLE
test: retrofit test for navigating->appeal-doc-upload

### DIFF
--- a/e2e-tests/cypress/integration/appeal-submission-tasklist-planningApplicationForm.feature
+++ b/e2e-tests/cypress/integration/appeal-submission-tasklist-planningApplicationForm.feature
@@ -1,0 +1,6 @@
+Feature: User chooses to provide their appeal submission document
+
+Scenario: The user needs to provide their appeal submission document
+  Given the user checks the status of their appeal
+  When the user selects to upload their appeal submission document
+  Then the user should be presented with opportunity to upload their appeal submission document

--- a/e2e-tests/cypress/integration/appeal-submission-tasklist-planningApplicationForm/appeal-submission-tasklist-planningApplicationForm.js
+++ b/e2e-tests/cypress/integration/appeal-submission-tasklist-planningApplicationForm/appeal-submission-tasklist-planningApplicationForm.js
@@ -1,0 +1,13 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+
+Given('the user checks the status of their appeal', () => {
+  cy.goToTaskListPage();
+});
+
+When('the user selects to upload their appeal submission document', () => {
+  cy.selectToUploadAppealSubmissionDocument();
+});
+
+Then('the user should be presented with opportunity to upload their appeal submission document', () => {
+  cy.confirmUserPresentedWithUploadAppealSubmissionDocument();
+});

--- a/e2e-tests/cypress/support/appeal-submission-tasklist/confirmUserPresentedWithUploadAppealSubmissionDocument.js
+++ b/e2e-tests/cypress/support/appeal-submission-tasklist/confirmUserPresentedWithUploadAppealSubmissionDocument.js
@@ -1,0 +1,4 @@
+module.exports = () => {
+  cy.url().should('contain','/appellant-submission/upload-application');
+  cy.wait(Cypress.env('demoDelay'));
+};

--- a/e2e-tests/cypress/support/appeal-submission-tasklist/selectToUploadAppealSubmissionDocument.js
+++ b/e2e-tests/cypress/support/appeal-submission-tasklist/selectToUploadAppealSubmissionDocument.js
@@ -1,0 +1,4 @@
+module.exports = () => {
+  cy.get('a[href*="/appellant-submission/upload-application"]').click();
+  cy.wait(Cypress.env('demoDelay'));
+};

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -127,6 +127,16 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  'selectToUploadAppealSubmissionDocument',
+  require('./appeal-submission-tasklist/selectToUploadAppealSubmissionDocument'),
+);
+
+Cypress.Commands.add(
+  'confirmUserPresentedWithUploadAppealSubmissionDocument',
+  require('./appeal-submission-tasklist/confirmUserPresentedWithUploadAppealSubmissionDocument'),
+);
+
+Cypress.Commands.add(
   'goToWhoAreYouPage',
   require('./appellant-submission-who-are-you/goToWhoAreYouPage'),
 );


### PR DESCRIPTION
## Ticket Number
UCD-1237

## Description of change
retrofit e2e tests showing navigation from tasklist page -> appeal submission doc upload page


## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] I have merged commits to avoid fixing things in this PR
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
