### PR TITLE
fix(forms-web-app): file size display helper - 1000, not 1024

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       APPEALS_SERVICE_API_URL: http://appeals-service-api:3000
       DOCUMENTS_SERVICE_API_URL: http://document-service-api:3000
       FILE_UPLOAD_DEBUG: "false"
-      FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 52428800
+      FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 50000000
       FILE_UPLOAD_USE_TEMP_FILES: "true"
       FILE_UPLOAD_TMP_PATH: "/tmp"
       SESSION_MONGODB_URL: mongodb://mongodb:27017/fwa-sessions

--- a/e2e-tests/create-large-test-files.sh
+++ b/e2e-tests/create-large-test-files.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -z "${FILE_UPLOAD_MAX_FILE_SIZE_BYTES}" ]]; then
-  MAX_SIZE=52428800
+  MAX_SIZE=50000000
 else
   MAX_SIZE=$FILE_UPLOAD_MAX_FILE_SIZE_BYTES
 fi

--- a/forms-web-app/src/lib/file-size-display-helper.js
+++ b/forms-web-app/src/lib/file-size-display-helper.js
@@ -2,6 +2,6 @@
 const suffixes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
 module.exports = (bytes) => {
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-  return (!bytes && '0 Bytes') || `${(bytes / 1024 ** i).toFixed()} ${suffixes[i]}`;
+  const i = Math.floor(Math.log(bytes) / Math.log(1000));
+  return (!bytes && '0 Bytes') || `${(bytes / 1000 ** i).toFixed()} ${suffixes[i]}`;
 };

--- a/forms-web-app/tests/unit/lib/file-size-display-helper.test.js
+++ b/forms-web-app/tests/unit/lib/file-size-display-helper.test.js
@@ -11,6 +11,10 @@ describe('lib/file-size-display-helper', () => {
       expected: '1 Bytes',
     },
     {
+      given: 1000,
+      expected: '1 KB',
+    },
+    {
       given: 1024,
       expected: '1 KB',
     },
@@ -19,7 +23,15 @@ describe('lib/file-size-display-helper', () => {
       expected: '1 MB',
     },
     {
+      given: 1000 ** 2,
+      expected: '1 MB',
+    },
+    {
       given: 1024 ** 3,
+      expected: '1 GB',
+    },
+    {
+      given: 1000 ** 3,
       expected: '1 GB',
     },
     {
@@ -27,7 +39,15 @@ describe('lib/file-size-display-helper', () => {
       expected: '1 TB',
     },
     {
+      given: 1000 ** 4,
+      expected: '1 TB',
+    },
+    {
       given: 1024 ** 5,
+      expected: '1 PB',
+    },
+    {
+      given: 1000 ** 5,
       expected: '1 PB',
     },
     {
@@ -35,12 +55,32 @@ describe('lib/file-size-display-helper', () => {
       expected: '1 EB',
     },
     {
+      given: 1000 ** 6,
+      expected: '1 EB',
+    },
+    {
       given: 1024 ** 7,
+      expected: '1 ZB',
+    },
+    {
+      given: 1000 ** 7,
       expected: '1 ZB',
     },
     {
       given: 1024 ** 8,
       expected: '1 YB',
+    },
+    {
+      given: 1000 ** 8,
+      expected: '1 YB',
+    },
+    {
+      given: 50000000,
+      expected: '50 MB',
+    },
+    {
+      given: 52428800,
+      expected: '52 MB',
     },
   ].forEach(({ given, expected }) => {
     it(`should display the expected file size - ${expected}`, () => {


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-880

## Description of change
<!-- Please describe the change -->
 file size display helper - 1000, not 1024

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] I have merged commits to avoid fixing things in this PR
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
