### PR TITLE
fix(forms-web-app): throw if created document is missing id

### DIFF
--- a/forms-web-app/src/lib/documents-api-wrapper.js
+++ b/forms-web-app/src/lib/documents-api-wrapper.js
@@ -44,5 +44,13 @@ exports.createDocument = async (appeal, formData) => {
     throw new Error(apiResponse.statusText);
   }
 
-  return apiResponse.json();
+  const response = await apiResponse.json();
+
+  if (!response.id) {
+    const msg = 'Document had no ID';
+    logger.warn({ response }, msg);
+    throw new Error(msg);
+  }
+
+  return response;
 };

--- a/forms-web-app/tests/unit/lib/documents-api-wrapper.test.js
+++ b/forms-web-app/tests/unit/lib/documents-api-wrapper.test.js
@@ -47,6 +47,29 @@ describe('lib/documents-api-wrapper', () => {
       expect(createDocument(mockAppeal, formData)).rejects.toThrow('No Content');
     });
 
+    it('should throw if the document response is missing an `id`', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          name: 'tmp-2-1607684291243',
+        }),
+        { status: 202 }
+      );
+      expect(createDocument(mockAppeal, formData)).rejects.toThrow('Document had no ID');
+    });
+
+    [null, undefined].forEach((given) => {
+      it(`should throw if the document response 'id' is ${given}`, async () => {
+        fetch.mockResponse(
+          JSON.stringify({
+            id: given,
+            name: 'tmp-2-1607684291243',
+          }),
+          { status: 202 }
+        );
+        expect(createDocument(mockAppeal, formData)).rejects.toThrow('Document had no ID');
+      });
+    });
+
     it('should return the expected response if the fetch status is 202', async () => {
       fetch.mockResponse(
         JSON.stringify({


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-830

## Description of change
<!-- Please describe the change -->
Throw an error if the document API service returns an object missing an `id`

The only way I can recreate the error raised by Karuna during testing is if the `id` is either `null` or `undefined`. The only way that could happen is when the document API call returns an object that is missing an `id`. The call is wrapped in a try / catch which throws anyway.

I'm confident the unit tests cover all the outcomes here. The situation as best I can see was a hazard of having the document service in a transitional state during dev, and should not be possible moving forwards. 

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
