### PR TITLE
Configure develop branch as release candidate branch

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,6 +2,14 @@
   "extends": [
     "semantic-release-monorepo"
   ],
+  "branches": [
+    "+([0-9])?(.{+([0-9]),x}).x",
+    "master",
+    {
+      "name": "develop",
+      "prerelease": "rc"
+    }
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ image separately, you must build the common image separately:
 docker build -t common ./common
 ```
 
+# Branching
+
+The default branch is the `develop` branch which generates release candidates
+of the software with releases generated from the `master` branch. This uses
+[Conventional Commit Format](#commit-message-format) and Semantic Release to
+generate the release numbers.
+
 # Releases
 
 Releases are done using the GitOps workflow. Lots can be found about [GitOps
@@ -108,7 +115,7 @@ variables which we want to apply (in this instance, just the URL).
 
 This repo uses [Semantic Release](https://semantic-release.gitbook.io) to
 generate release version numbers so it is imperative that all commits to the
-`master` branch are done using the [correct
+`master` and `develop` branch are done using the [correct
 format](https://semantic-release.gitbook.io/semantic-release/#commit-message-format).
 
 ## Commitizen


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1283

## Description of change
<!-- Please describe the change -->
This configures the `develop` branch as a release candidate branch. This will require most in-sprint pull requests being raised against the `develop` branch (not the `master`). The dev cluster will track rapid changes as-is, and then pre-prod (and later, prod) will be able to track the slower changes.

The intention is that there will be fewer PRs against `master` per sprint and the minor semver number will  typically only increment once per sprint.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [x] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.

# Todo before merging

 - [ ] Change default branch to `develop`
 - [x] Update documentation
 - [x] Change any open PRs to be against `develop` (not `master`)
 - [ ] Make `develop` and `master` protected branches (same rules as currently on `master`)
