### PR TITLE
fix: application number page should show value if there is one

### DIFF
--- a/e2e-tests/cypress/integration/appellant-submission-planning-application-number.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-planning-application-number.feature
@@ -4,7 +4,7 @@ Feature: Appellant submits a planning application reference number so that the p
   Scenario Outline: Prospective appellant provides a valid planning application number
     Given the user is prompted to provide a planning application number
     When the user provides a planning application number <valid application number>
-    Then the appeal is updated with the provided planning application number
+    Then the appeal is updated with the <valid application number>
 
       Examples:
           | valid application number |

--- a/e2e-tests/cypress/integration/appellant-submission-planning-application-number/appellant-submission-planning-application-number.js
+++ b/e2e-tests/cypress/integration/appellant-submission-planning-application-number/appellant-submission-planning-application-number.js
@@ -8,8 +8,8 @@ When('the user provides a planning application number {string}', (valid_number) 
   cy.providePlanningApplicationNumber(valid_number);
 });
 
-Then('the appeal is updated with the provided planning application number', () => {
-  cy.confirmPlanningApplicationNumberHasUpdated();
+Then('the appeal is updated with the {string}', (applicationNumber) => {
+  cy.confirmPlanningApplicationNumberHasUpdated(applicationNumber);
 });
 
 Then('the user is informed that the application number is not valid because {string}', (reason) => {

--- a/e2e-tests/cypress/integration/appellant-submission-who-are-you.feature
+++ b/e2e-tests/cypress/integration/appellant-submission-who-are-you.feature
@@ -3,11 +3,13 @@
 Feature: A user is asked if he or she's the original appellant
   If the user is not the original appellant, his name should be asked
 
-
   Scenario: The user is the original appellant
     When the user has stated that they "are not" the original appellant
     Then the user will "not be" asked who they are representing
+    And the user can see that their appeal has "not been" updated with the provided answer
+
 
   Scenario: The user is not the original appellant
     When the user has stated that they "are" the original appellant
     Then the user will "be" asked who they are representing
+    And the user can see that their appeal has "not been" updated with the provided answer

--- a/e2e-tests/cypress/support/appellant-submission-planning-application-number/confirmPlanningApplicationNumberHasUpdated.js
+++ b/e2e-tests/cypress/support/appellant-submission-planning-application-number/confirmPlanningApplicationNumberHasUpdated.js
@@ -1,6 +1,14 @@
-module.exports = () => {
+module.exports = (applicationNumber) => {
   //TODO validate this on the check-your-answers page once this is implemented
   cy.url().should('include','/appellant-submission/upload-application');
 
   cy.wait(Cypress.env('demoDelay'));
+
+  // revisit the application number page and prove the number is still there..
+  cy.visit('/appellant-submission/application-number');
+
+  cy.get('[data-cy="application-number"]').should('have.value', applicationNumber);
+
+  cy.wait(Cypress.env('demoDelay'));
+
 };

--- a/forms-web-app/src/views/appellant-submission/application-number.njk
+++ b/forms-web-app/src/views/appellant-submission/application-number.njk
@@ -36,7 +36,7 @@
           hint: {
             text: "You can find this on the decision letter from your local planning department"
           },
-          value: appeal["application-number"],
+          value: appeal.requiredDocumentsSection.applicationNumber,
           errorMessage: errors['application-number'] and {
             text: errors['application-number'].msg
           }


### PR DESCRIPTION
## Ticket Number

UCD-892/UCD-1291

## Description of change
Improved test shows that we're not displaying the application-number properly when we re-visit the screen.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
