### PR TITLE
fix(forms-web-app): collated section count rather than items in section

### DIFF
--- a/forms-web-app/src/lib/count-task.js
+++ b/forms-web-app/src/lib/count-task.js
@@ -7,5 +7,21 @@ module.exports = (sections) => {
     nbCompleted += section.items.filter((subSection) => subSection.status === 'COMPLETED').length;
   });
 
-  return { nbTasks, nbCompleted };
+  const completedSections = sections.reduce(
+    (acc, section) =>
+      section.items.filter((subSection) => subSection.status === 'COMPLETED').length ===
+      section.items.length
+        ? acc + 1
+        : acc,
+    0
+  );
+
+  return {
+    nbTasks,
+    nbCompleted,
+    sections: {
+      count: sections.length,
+      completed: completedSections,
+    },
+  };
 };

--- a/forms-web-app/src/views/appellant-submission/task-list.njk
+++ b/forms-web-app/src/views/appellant-submission/task-list.njk
@@ -16,7 +16,7 @@
     <p>A householder appeal must be received by the Planning Inspectorate within 12 weeks of the decision date.</p>
     <p>If you do not submit it in time, you will lose your right to appeal.</p>
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">{{ applicationStatus }}</h2>
-    <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ sectionInfo.nbCompleted }} of {{sectionInfo.nbTasks}} sections.</p>
+    <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ sectionInfo.sections.completed }} of {{sectionInfo.sections.count}} sections.</p>
 
     {{ mojTaskList({
       sections: sections

--- a/forms-web-app/tests/unit/controllers/appellant-submission/task-list.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/task-list.test.js
@@ -12,7 +12,14 @@ describe('controller/appellant-submission/task-list', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.TASK_LIST, {
         applicationStatus: 'Application incomplete',
-        sectionInfo: { nbTasks: 12, nbCompleted: 0 },
+        sectionInfo: {
+          nbTasks: 12,
+          nbCompleted: 0,
+          sections: {
+            count: 5,
+            completed: 0,
+          },
+        },
         sections: [
           {
             heading: {
@@ -189,7 +196,14 @@ describe('controller/appellant-submission/task-list', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.TASK_LIST, {
         applicationStatus: 'Application incomplete',
-        sectionInfo: { nbTasks: 12, nbCompleted: 6 },
+        sectionInfo: {
+          nbTasks: 12,
+          nbCompleted: 6,
+          sections: {
+            count: 5,
+            completed: 1,
+          },
+        },
         sections: [
           {
             heading: {
@@ -367,7 +381,14 @@ describe('controller/appellant-submission/task-list', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.TASK_LIST, {
         applicationStatus: 'Application incomplete',
-        sectionInfo: { nbTasks: 12, nbCompleted: 7 },
+        sectionInfo: {
+          nbTasks: 12,
+          nbCompleted: 7,
+          sections: {
+            count: 5,
+            completed: 2,
+          },
+        },
         sections: [
           {
             heading: {

--- a/forms-web-app/tests/unit/lib/count-task.test.js
+++ b/forms-web-app/tests/unit/lib/count-task.test.js
@@ -3,26 +3,30 @@ const countTasks = require('../../../src/lib/count-task');
 describe('lib/count-task', () => {
   [
     {
+      description: 'One section, one task in progress',
       given: [{ items: [{ status: 'IN PROGRESS' }] }],
-      expected: { nbTasks: 1, nbCompleted: 0 },
+      expected: { nbTasks: 1, nbCompleted: 0, sections: { count: 1, completed: 0 } },
     },
     {
+      description: 'One section, one task completed',
       given: [{ items: [{ status: 'COMPLETED' }] }],
-      expected: { nbTasks: 1, nbCompleted: 1 },
+      expected: { nbTasks: 1, nbCompleted: 1, sections: { count: 1, completed: 1 } },
     },
     {
+      description: 'One section, two tasks, one completed, one in progress',
       given: [{ items: [{ status: 'COMPLETED' }, { status: 'IN PROGRESS' }] }],
-      expected: { nbTasks: 2, nbCompleted: 1 },
+      expected: { nbTasks: 2, nbCompleted: 1, sections: { count: 1, completed: 0 } },
     },
     {
+      description: 'Two sections, two tasks each, all but one completed',
       given: [
         { items: [{ status: 'COMPLETED' }, { status: 'COMPLETED' }] },
         { items: [{ status: 'COMPLETED' }, { status: 'IN PROGRESS' }] },
       ],
-      expected: { nbTasks: 4, nbCompleted: 3 },
+      expected: { nbTasks: 4, nbCompleted: 3, sections: { count: 2, completed: 1 } },
     },
-  ].forEach(({ given, expected }) => {
-    it(`should display the expected file size - ${expected}`, () => {
+  ].forEach(({ description, given, expected }) => {
+    it(`should return the counted tasks - ${description}`, () => {
       expect(countTasks(given)).toStrictEqual(expected);
     });
   });


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-

## Description of change
<!-- Please describe the change -->
Prototype: You have completed 0 of 5 sections.
Ours: You have completed 0 of 12 sections.

Sections competition is based on all sub items being complete.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
