### PR TITLE
chore(lpa-trialists): set hillingdon as trialist and remove adur/telford

### DIFF
--- a/charts/app/templates/lpa.yaml
+++ b/charts/app/templates/lpa.yaml
@@ -6,14 +6,9 @@ metadata:
 data:
   lpa-trialists.json: |
     [{
-      "id": "E60000281",
-      "inTrial": true
-    }, {
-      "id": "E60000019",
-      "inTrial": false
-    }, {
-      "id": "E60000116",
-      "inTrial": true
+      "id": "E60000213",
+      "inTrial": true,
+      "horizonId": "R5510"
     }]
 ---
 # @todo replace this with a cronjob to get the lpa data from the ONS


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1090

## Description of change
<!-- Please describe the change -->
Update trialists:
 - remove Adur
 - remove Telford and Wrekin
 - add Hillingdon

Tested on my cluster and working

This also updates the the `lpa-trialists.json` file (both test and in ConfigMap) to include the `horizonId`. The Hillingdon ID has been provided by Anthony

**IMPORTANT** this does not change the  in trial LPAs in development. They remain Adur and Telford & Wrekin

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [x] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
