### PR TITLE
fix(forms-web-app): default to null rather than false for unselected …

### DIFF
--- a/forms-web-app/src/controllers/appellant-submission/site-access-safety.js
+++ b/forms-web-app/src/controllers/appellant-submission/site-access-safety.js
@@ -3,6 +3,9 @@ const { getNextUncompletedTask } = require('../../services/task.service');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
 const { getTaskStatus } = require('../../services/task.service');
+const {
+  validSiteAccessSafetyOptions,
+} = require('../../validators/appellant-submission/site-access-safety');
 
 const sectionName = 'appealSiteSection';
 const taskName = 'healthAndSafety';
@@ -21,8 +24,16 @@ exports.postSiteAccessSafety = async (req, res) => {
   const { appeal } = req.session;
   const task = appeal[sectionName][taskName];
 
-  task.hasIssues = req.body['site-access-safety'] === 'yes';
-  task.healthAndSafetyIssues = req.body['site-access-safety-concerns'];
+  let hasIssues = null;
+  if (validSiteAccessSafetyOptions.includes(req.body['site-access-safety'])) {
+    hasIssues = req.body['site-access-safety'] === 'yes';
+  }
+  task.hasIssues = hasIssues;
+
+  task.healthAndSafetyIssues =
+    typeof req.body['site-access-safety-concerns'] !== 'undefined'
+      ? req.body['site-access-safety-concerns']
+      : null;
 
   if (Object.keys(errors).length > 0) {
     res.render(VIEW.APPELLANT_SUBMISSION.SITE_ACCESS_SAFETY, {

--- a/forms-web-app/src/controllers/appellant-submission/site-access.js
+++ b/forms-web-app/src/controllers/appellant-submission/site-access.js
@@ -3,6 +3,7 @@ const { getNextUncompletedTask } = require('../../services/task.service');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
 const { getTaskStatus } = require('../../services/task.service');
+const { validSiteAccessOptions } = require('../../validators/appellant-submission/site-access');
 
 const sectionName = 'appealSiteSection';
 const taskName = 'siteAccess';
@@ -21,12 +22,17 @@ exports.postSiteAccess = async (req, res) => {
   const { appeal } = req.session;
   const task = appeal[sectionName][taskName];
 
-  const canInspectorSeeWholeSiteFromPublicRoad = req.body['site-access'] === 'yes';
-
+  let canInspectorSeeWholeSiteFromPublicRoad = null;
+  if (validSiteAccessOptions.includes(req.body['site-access'])) {
+    canInspectorSeeWholeSiteFromPublicRoad = req.body['site-access'] === 'yes';
+  }
   task.canInspectorSeeWholeSiteFromPublicRoad = canInspectorSeeWholeSiteFromPublicRoad;
-  task.howIsSiteAccessRestricted = canInspectorSeeWholeSiteFromPublicRoad
-    ? ''
-    : req.body['site-access-more-detail'];
+
+  let howIsSiteAccessRestricted = null;
+  if (canInspectorSeeWholeSiteFromPublicRoad === false) {
+    howIsSiteAccessRestricted = req.body['site-access-more-detail'];
+  }
+  task.howIsSiteAccessRestricted = howIsSiteAccessRestricted;
 
   if (Object.keys(errors).length > 0) {
     res.render(VIEW.APPELLANT_SUBMISSION.SITE_ACCESS, {

--- a/forms-web-app/src/controllers/appellant-submission/site-ownership-certb.js
+++ b/forms-web-app/src/controllers/appellant-submission/site-ownership-certb.js
@@ -2,6 +2,9 @@ const logger = require('../../lib/logger');
 const { getNextUncompletedTask, getTaskStatus } = require('../../services/task.service');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
+const {
+  validSiteOwnershipCertBOptions,
+} = require('../../validators/appellant-submission/site-ownership-certb');
 
 const sectionName = 'appealSiteSection';
 const taskName = 'siteOwnership';
@@ -20,7 +23,11 @@ exports.postSiteOwnershipCertB = async (req, res) => {
   const { appeal } = req.session;
   const task = appeal[sectionName][taskName];
 
-  task.haveOtherOwnersBeenTold = req.body['have-other-owners-been-told'] === 'yes';
+  let haveOtherOwnersBeenTold = null;
+  if (validSiteOwnershipCertBOptions.includes(req.body['have-other-owners-been-told'])) {
+    haveOtherOwnersBeenTold = req.body['have-other-owners-been-told'] === 'yes';
+  }
+  task.haveOtherOwnersBeenTold = haveOtherOwnersBeenTold;
 
   if (Object.keys(errors).length > 0) {
     res.render(VIEW.APPELLANT_SUBMISSION.SITE_OWNERSHIP_CERTB, {

--- a/forms-web-app/src/controllers/appellant-submission/site-ownership.js
+++ b/forms-web-app/src/controllers/appellant-submission/site-ownership.js
@@ -2,6 +2,9 @@ const logger = require('../../lib/logger');
 const { getNextUncompletedTask, getTaskStatus } = require('../../services/task.service');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
+const {
+  validSiteOwnershipOptions,
+} = require('../../validators/appellant-submission/site-ownership');
 
 const sectionName = 'appealSiteSection';
 const taskName = 'siteOwnership';
@@ -20,7 +23,10 @@ exports.postSiteOwnership = async (req, res) => {
   const { appeal } = req.session;
   const task = appeal[sectionName][taskName];
 
-  const ownsWholeSite = req.body['site-ownership'] === 'yes';
+  let ownsWholeSite = null;
+  if (validSiteOwnershipOptions.includes(req.body['site-ownership'])) {
+    ownsWholeSite = req.body['site-ownership'] === 'yes';
+  }
   task.ownsWholeSite = ownsWholeSite;
   // if ownsWholeSite is true then haveOtherOwnersBeenTold needs to be null
   task.haveOtherOwnersBeenTold = ownsWholeSite ? null : task.haveOtherOwnersBeenTold;

--- a/forms-web-app/src/validators/appellant-submission/site-access-safety.js
+++ b/forms-web-app/src/validators/appellant-submission/site-access-safety.js
@@ -1,11 +1,13 @@
 const { body } = require('express-validator');
 
+const validSiteAccessSafetyOptions = ['yes', 'no'];
+
 const ruleSiteAccessSafety = () =>
   body('site-access-safety')
     .notEmpty()
     .withMessage('Select No if there are no health and safety issues on the appeal site')
     .bail()
-    .isIn(['yes', 'no']);
+    .isIn(validSiteAccessSafetyOptions);
 
 const ruleSiteAccessSafetyConcerns = () =>
   body('site-access-safety-concerns')
@@ -20,4 +22,5 @@ const rules = () => [ruleSiteAccessSafety(), ruleSiteAccessSafetyConcerns()];
 
 module.exports = {
   rules,
+  validSiteAccessSafetyOptions,
 };

--- a/forms-web-app/src/validators/appellant-submission/site-access.js
+++ b/forms-web-app/src/validators/appellant-submission/site-access.js
@@ -1,11 +1,13 @@
 const { body } = require('express-validator');
 
+const validSiteAccessOptions = ['yes', 'no'];
+
 const ruleSiteAccess = () =>
   body('site-access')
     .notEmpty()
     .withMessage('Select Yes if the appeal site can be seen from a public road')
     .bail()
-    .isIn(['yes', 'no']);
+    .isIn(validSiteAccessOptions);
 
 const ruleSiteAccessMoreDetail = () =>
   body('site-access-more-detail')
@@ -17,4 +19,5 @@ const rules = () => [ruleSiteAccess(), ruleSiteAccessMoreDetail()];
 
 module.exports = {
   rules,
+  validSiteAccessOptions,
 };

--- a/forms-web-app/src/validators/appellant-submission/site-ownership-certb.js
+++ b/forms-web-app/src/validators/appellant-submission/site-ownership-certb.js
@@ -1,11 +1,13 @@
 const { body } = require('express-validator');
 
+const validSiteOwnershipCertBOptions = ['yes', 'no'];
+
 const ruleSiteOwnershipCertB = () =>
   body('have-other-owners-been-told')
     .notEmpty()
     .withMessage('Select yes if you have told the other owners')
     .bail()
-    .isIn(['yes', 'no']);
+    .isIn(validSiteOwnershipCertBOptions);
 
 const rules = () => {
   return [ruleSiteOwnershipCertB()];
@@ -13,4 +15,5 @@ const rules = () => {
 
 module.exports = {
   rules,
+  validSiteOwnershipCertBOptions,
 };

--- a/forms-web-app/src/validators/appellant-submission/site-ownership.js
+++ b/forms-web-app/src/validators/appellant-submission/site-ownership.js
@@ -1,11 +1,13 @@
 const { body } = require('express-validator');
 
+const validSiteOwnershipOptions = ['yes', 'no'];
+
 const ruleSiteOwnership = () =>
   body('site-ownership')
     .notEmpty()
     .withMessage('Select yes if you own the whole appeal site')
     .bail()
-    .isIn(['yes', 'no']);
+    .isIn(validSiteOwnershipOptions);
 
 const rules = () => {
   return [ruleSiteOwnership()];
@@ -13,4 +15,5 @@ const rules = () => {
 
 module.exports = {
   rules,
+  validSiteOwnershipOptions,
 };

--- a/forms-web-app/tests/unit/controllers/appellant-submission/appeal-statement.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/appeal-statement.test.js
@@ -19,7 +19,7 @@ const res = mockRes();
 const sectionName = 'yourAppealSection';
 const taskName = 'appealStatement';
 
-describe('controller/appellant-submission/appeal-statement', () => {
+describe('controllers/appellant-submission/appeal-statement', () => {
   describe('getAppealStatement', () => {
     it('should call the correct template', async () => {
       const req = mockReq();

--- a/forms-web-app/tests/unit/controllers/appellant-submission/applicant-name.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/applicant-name.test.js
@@ -16,7 +16,7 @@ const res = mockRes();
 const sectionName = 'aboutYouSection';
 const taskName = 'yourDetails';
 
-describe('controller/appellant-submission/applicant-name', () => {
+describe('controllers/appellant-submission/applicant-name', () => {
   describe('getApplicantName', () => {
     it('should call the correct template', () => {
       applicantNameController.getApplicantName(req, res);

--- a/forms-web-app/tests/unit/controllers/appellant-submission/application-number.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/application-number.test.js
@@ -14,7 +14,7 @@ const res = mockRes();
 const sectionName = 'requiredDocumentsSection';
 const taskName = 'applicationNumber';
 
-describe('controller/appellant-submission/application-number', () => {
+describe('controllers/appellant-submission/application-number', () => {
   describe('getApplicationNumber', () => {
     it('should call the correct template', () => {
       applicationNumberController.getApplicationNumber(req, res);

--- a/forms-web-app/tests/unit/controllers/appellant-submission/site-access-safety.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/site-access-safety.test.js
@@ -16,7 +16,7 @@ const res = mockRes();
 const sectionName = 'appealSiteSection';
 const taskName = 'healthAndSafety';
 
-describe('controller/appellant-submission/site-access-safety', () => {
+describe('controllers/appellant-submission/site-access-safety', () => {
   describe('getSiteAccessSafety', () => {
     it('should call the correct template', () => {
       siteAccessSafetyController.getSiteAccessSafety(req, res);
@@ -41,7 +41,16 @@ describe('controller/appellant-submission/site-access-safety', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.SITE_ACCESS_SAFETY, {
-        appeal: req.session.appeal,
+        appeal: {
+          ...req.session.appeal,
+          appealSiteSection: {
+            ...req.session.appeal.appealSiteSection,
+            healthAndSafety: {
+              hasIssues: null,
+              healthAndSafetyIssues: null,
+            },
+          },
+        },
         errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });

--- a/forms-web-app/tests/unit/controllers/appellant-submission/site-access.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/site-access.test.js
@@ -10,13 +10,18 @@ jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/services/task.service');
 jest.mock('../../../../src/lib/logger');
 
-const req = mockReq();
-const res = mockRes();
-
 const sectionName = 'appealSiteSection';
 const taskName = 'siteAccess';
 
-describe('controller/appellant-submission/site-access', () => {
+describe('controllers/appellant-submission/site-access', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+  });
+
   describe('getSiteAccess', () => {
     it('should call the correct template', () => {
       siteAccessController.getSiteAccess(req, res);
@@ -41,7 +46,16 @@ describe('controller/appellant-submission/site-access', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.SITE_ACCESS, {
-        appeal: req.session.appeal,
+        appeal: {
+          ...req.session.appeal,
+          appealSiteSection: {
+            ...req.session.appeal.appealSiteSection,
+            siteAccess: {
+              canInspectorSeeWholeSiteFromPublicRoad: null,
+              howIsSiteAccessRestricted: null,
+            },
+          },
+        },
         errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
@@ -67,7 +81,7 @@ describe('controller/appellant-submission/site-access', () => {
       });
     });
 
-    it('should redirect to `/appellant-submission/site-access-safety` if valid', async () => {
+    it('should redirect to `/appellant-submission/site-access-safety` if `site-access` is `yes`', async () => {
       createOrUpdateAppeal.mockImplementation(() => JSON.stringify({ good: 'data' }));
       getNextUncompletedTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.SITE_ACCESS_SAFETY}`,
@@ -85,6 +99,30 @@ describe('controller/appellant-submission/site-access', () => {
       const { empty: goodAppeal } = APPEAL_DOCUMENT;
       goodAppeal[sectionName][taskName].canInspectorSeeWholeSiteFromPublicRoad = true;
       goodAppeal[sectionName][taskName].howIsSiteAccessRestricted = undefined;
+      goodAppeal.sectionStates[sectionName][taskName] = 'COMPLETED';
+
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(goodAppeal);
+    });
+
+    it('should redirect to `/appellant-submission/site-access-safety` if `site-access` is `no`', async () => {
+      createOrUpdateAppeal.mockImplementation(() => JSON.stringify({ good: 'data' }));
+      getNextUncompletedTask.mockReturnValue({
+        href: `/${VIEW.APPELLANT_SUBMISSION.SITE_ACCESS_SAFETY}`,
+      });
+      const mockRequest = {
+        ...req,
+        body: {
+          'site-access': 'no',
+          'site-access-more-detail': 'some more detail',
+        },
+      };
+      await siteAccessController.postSiteAccess(mockRequest, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.APPELLANT_SUBMISSION.SITE_ACCESS_SAFETY}`);
+
+      const { empty: goodAppeal } = APPEAL_DOCUMENT;
+      goodAppeal[sectionName][taskName].canInspectorSeeWholeSiteFromPublicRoad = false;
+      goodAppeal[sectionName][taskName].howIsSiteAccessRestricted = 'more detail';
       goodAppeal.sectionStates[sectionName][taskName] = 'COMPLETED';
 
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(goodAppeal);

--- a/forms-web-app/tests/unit/controllers/appellant-submission/site-location.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/site-location.test.js
@@ -16,7 +16,7 @@ const res = mockRes();
 const sectionName = 'appealSiteSection';
 const taskName = 'siteAddress';
 
-describe('controller/appellant-submission/site-location', () => {
+describe('controllers/appellant-submission/site-location', () => {
   describe('getSiteLocation', () => {
     it('should call the correct template', () => {
       siteLocationController.getSiteLocation(req, res);

--- a/forms-web-app/tests/unit/controllers/appellant-submission/site-ownership-certb.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/site-ownership-certb.test.js
@@ -16,7 +16,7 @@ const res = mockRes();
 const sectionName = 'appealSiteSection';
 const taskName = 'siteOwnership';
 
-describe('controller/appellant-submission/site-ownership-certb', () => {
+describe('controllers/appellant-submission/site-ownership-certb', () => {
   describe('getSiteOwnershipCertB', () => {
     it('should call the correct template', () => {
       siteOwnershipCertBController.getSiteOwnershipCertB(req, res);
@@ -41,7 +41,16 @@ describe('controller/appellant-submission/site-ownership-certb', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.SITE_OWNERSHIP_CERTB, {
-        appeal: req.session.appeal,
+        appeal: {
+          ...req.session.appeal,
+          appealSiteSection: {
+            ...req.session.appeal.appealSiteSection,
+            siteOwnership: {
+              ownsWholeSite: null,
+              haveOtherOwnersBeenTold: null,
+            },
+          },
+        },
         errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });

--- a/forms-web-app/tests/unit/controllers/appellant-submission/site-ownership.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/site-ownership.test.js
@@ -13,7 +13,7 @@ jest.mock('../../../../src/lib/logger');
 const sectionName = 'appealSiteSection';
 const taskName = 'siteOwnership';
 
-describe('controller/appellant-submission/site-ownership', () => {
+describe('controllers/appellant-submission/site-ownership', () => {
   let req;
   let res;
 
@@ -48,7 +48,16 @@ describe('controller/appellant-submission/site-ownership', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.SITE_OWNERSHIP, {
-        appeal: req.session.appeal,
+        appeal: {
+          ...req.session.appeal,
+          appealSiteSection: {
+            ...req.session.appeal.appealSiteSection,
+            siteOwnership: {
+              ownsWholeSite: null,
+              haveOtherOwnersBeenTold: null,
+            },
+          },
+        },
         errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });

--- a/forms-web-app/tests/unit/controllers/appellant-submission/supporting-documents.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/supporting-documents.test.js
@@ -5,7 +5,7 @@ const { VIEW } = require('../../../../src/lib/views');
 const req = mockReq();
 const res = mockRes();
 
-describe('controller/appellant-submission/supporting-documents', () => {
+describe('controllers/appellant-submission/supporting-documents', () => {
   describe('getSupportingDocuments', () => {
     it('should call the correct template', () => {
       supportingDocumentsController.getSupportingDocuments(req, res);

--- a/forms-web-app/tests/unit/controllers/appellant-submission/task-list.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/task-list.test.js
@@ -2,7 +2,7 @@ const taskListController = require('../../../../src/controllers/appellant-submis
 const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
 
-describe('controller/appellant-submission/task-list', () => {
+describe('controllers/appellant-submission/task-list', () => {
   describe('getTaskList', () => {
     it('All the tasks except check answers should be in not started', () => {
       const req = mockReq();

--- a/forms-web-app/tests/unit/controllers/appellant-submission/upload-application.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/upload-application.test.js
@@ -17,7 +17,7 @@ const res = mockRes();
 const sectionName = 'requiredDocumentsSection';
 const taskName = 'originalApplication';
 
-describe('controller/appellant-submission/upload-application', () => {
+describe('controllers/appellant-submission/upload-application', () => {
   describe('getUploadApplication', () => {
     it('should call the correct template', () => {
       const req = mockReq();

--- a/forms-web-app/tests/unit/controllers/appellant-submission/upload-decision.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/upload-decision.test.js
@@ -17,7 +17,7 @@ const res = mockRes();
 const sectionName = 'requiredDocumentsSection';
 const taskName = 'decisionLetter';
 
-describe('controller/appellant-submission/upload-decision', () => {
+describe('controllers/appellant-submission/upload-decision', () => {
   describe('getUploadDecision', () => {
     it('should call the correct template', () => {
       const req = mockReq();

--- a/forms-web-app/tests/unit/controllers/appellant-submission/who-are-you.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/who-are-you.test.js
@@ -14,7 +14,7 @@ const res = mockRes();
 const sectionName = 'aboutYouSection';
 const taskName = 'yourDetails';
 
-describe('controller/appellant-submission/who-are-you', () => {
+describe('controllers/appellant-submission/who-are-you', () => {
   describe('getWhoAreYou', () => {
     it('should call the correct template', () => {
       const req = mockReq();

--- a/forms-web-app/tests/unit/controllers/appellant-submission/your-details.test.js
+++ b/forms-web-app/tests/unit/controllers/appellant-submission/your-details.test.js
@@ -15,7 +15,7 @@ const res = mockRes();
 const sectionName = 'aboutYouSection';
 const taskName = 'yourDetails';
 
-describe('controller/appellant-submission/your-details', () => {
+describe('controllers/appellant-submission/your-details', () => {
   describe('getYourDetails', () => {
     it('should call the correct template', () => {
       yourDetailsController.getYourDetails(req, res);

--- a/forms-web-app/tests/unit/controllers/application-number.test.js
+++ b/forms-web-app/tests/unit/controllers/application-number.test.js
@@ -5,7 +5,7 @@ const { VIEW } = require('../../../src/lib/views');
 const req = mockReq();
 const res = mockRes();
 
-describe('controller/application-number', () => {
+describe('controllers/application-number', () => {
   describe('getApplicationNumber', () => {
     it('should call the correct template', () => {
       applicationNumberController.getApplicationNumber(req, res);

--- a/forms-web-app/tests/unit/controllers/check-answers.test.js
+++ b/forms-web-app/tests/unit/controllers/check-answers.test.js
@@ -5,7 +5,7 @@ const { VIEW } = require('../../../src/lib/views');
 const req = mockReq();
 const res = mockRes();
 
-describe('controller/check-answers', () => {
+describe('controllers/check-answers', () => {
   describe('getCheckAnswers', () => {
     it('should call the correct template', () => {
       checkAnswersController.getCheckAnswers(req, res);

--- a/forms-web-app/tests/unit/controllers/confirmation.test.js
+++ b/forms-web-app/tests/unit/controllers/confirmation.test.js
@@ -5,7 +5,7 @@ const { VIEW } = require('../../../src/lib/views');
 const req = mockReq();
 const res = mockRes();
 
-describe('controller/confirmation', () => {
+describe('controllers/confirmation', () => {
   describe('getConfirmation', () => {
     it('should call the correct template', () => {
       const appellantEmail = 'hello@example.com';

--- a/forms-web-app/tests/unit/controllers/eligibility/appeal-statement.test.js
+++ b/forms-web-app/tests/unit/controllers/eligibility/appeal-statement.test.js
@@ -5,7 +5,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const req = mockReq();
 const res = mockRes();
 
-describe('controller/eligibility/appeal-statement', () => {
+describe('controllers/eligibility/appeal-statement', () => {
   describe('getNoDecision', () => {
     it('should call the correct template', () => {
       appealStatementController.getAppealStatement(req, res);

--- a/forms-web-app/tests/unit/controllers/eligibility/decision-date.test.js
+++ b/forms-web-app/tests/unit/controllers/eligibility/decision-date.test.js
@@ -4,7 +4,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const req = mockReq();
 const res = mockRes();
 
-describe('controller/eligibility/decision-date', () => {
+describe('controllers/eligibility/decision-date', () => {
   describe('getNoDecision', () => {
     it('should call the correct template', () => {
       decisionDateController.getNoDecision(req, res);

--- a/forms-web-app/tests/unit/controllers/eligibility/planning-department.test.js
+++ b/forms-web-app/tests/unit/controllers/eligibility/planning-department.test.js
@@ -15,7 +15,7 @@ const departmentsData = {
 
 getDepartmentData.mockResolvedValue(departmentsData);
 
-describe('controller/eligibility/planning-department', () => {
+describe('controllers/eligibility/planning-department', () => {
   describe('Planning Department Controller Tests', () => {
     it('should call the correct template', async () => {
       await planningDepartmentController.getPlanningDepartment(req, res);

--- a/forms-web-app/tests/unit/controllers/index.test.js
+++ b/forms-web-app/tests/unit/controllers/index.test.js
@@ -4,7 +4,7 @@ const { mockReq, mockRes } = require('../mocks');
 const req = mockReq();
 const res = mockRes();
 
-describe('controller/index', () => {
+describe('controllers/index', () => {
   describe('getSubmission', () => {
     it('should call the correct template', () => {
       indexController.getIndex(req, res);

--- a/forms-web-app/tests/unit/controllers/submission.test.js
+++ b/forms-web-app/tests/unit/controllers/submission.test.js
@@ -5,7 +5,7 @@ const { VIEW } = require('../../../src/lib/views');
 const req = mockReq();
 const res = mockRes();
 
-describe('controller/submission', () => {
+describe('controllers/submission', () => {
   describe('getSubmission', () => {
     it('should call the correct template', () => {
       submissionController.getSubmission(req, res);

--- a/forms-web-app/tests/unit/validators/appellant-submission/site-access-safety.test.js
+++ b/forms-web-app/tests/unit/validators/appellant-submission/site-access-safety.test.js
@@ -1,5 +1,8 @@
 const { validationResult } = require('express-validator');
-const { rules } = require('../../../../src/validators/appellant-submission/site-access-safety');
+const {
+  rules,
+  validSiteAccessSafetyOptions,
+} = require('../../../../src/validators/appellant-submission/site-access-safety');
 const { testExpressValidatorMiddleware } = require('../validation-middleware-helper');
 
 describe('validators/appellant-submission/site-access-safety', () => {
@@ -149,6 +152,12 @@ describe('validators/appellant-submission/site-access-safety', () => {
         const result = validationResult(mockReq);
         expected(result);
       });
+    });
+  });
+
+  describe('validSiteAccessSafetyOptions', () => {
+    it('should define the expected valid site access safety options', () => {
+      expect(validSiteAccessSafetyOptions).toEqual(['yes', 'no']);
     });
   });
 });

--- a/forms-web-app/tests/unit/validators/appellant-submission/site-access.test.js
+++ b/forms-web-app/tests/unit/validators/appellant-submission/site-access.test.js
@@ -1,5 +1,8 @@
 const { validationResult } = require('express-validator');
-const { rules } = require('../../../../src/validators/appellant-submission/site-access');
+const {
+  rules,
+  validSiteAccessOptions,
+} = require('../../../../src/validators/appellant-submission/site-access');
 const { testExpressValidatorMiddleware } = require('../validation-middleware-helper');
 
 describe('validators/appellant-submission/site-access', () => {
@@ -129,6 +132,12 @@ describe('validators/appellant-submission/site-access', () => {
         const result = validationResult(mockReq);
         expected(result);
       });
+    });
+  });
+
+  describe('validSiteAccessOptions', () => {
+    it('should define the expected valid site access options', () => {
+      expect(validSiteAccessOptions).toEqual(['yes', 'no']);
     });
   });
 });

--- a/forms-web-app/tests/unit/validators/appellant-submission/site-ownership-certb.test.js
+++ b/forms-web-app/tests/unit/validators/appellant-submission/site-ownership-certb.test.js
@@ -1,7 +1,13 @@
-jest.mock('../../../../src/services/department.service');
-const { rules } = require('../../../../src/validators/appellant-submission/site-ownership-certb');
+const { validationResult } = require('express-validator');
+const {
+  rules,
+  validSiteOwnershipCertBOptions,
+} = require('../../../../src/validators/appellant-submission/site-ownership-certb');
+const { testExpressValidatorMiddleware } = require('../validation-middleware-helper');
 
-describe('validators/appellant-submission/site-ownership-certb', () => {
+jest.mock('../../../../src/services/department.service');
+
+describe('validators/appellant-submission/have-other-owners-been-told-certb', () => {
   describe('rules', () => {
     it('is configured with the expected rules', () => {
       expect(rules().length).toEqual(1);
@@ -24,6 +30,76 @@ describe('validators/appellant-submission/site-ownership-certb', () => {
         expect(rule.stack[2].validator.name).toEqual('isIn');
         expect(rule.stack[2].options).toEqual([['yes', 'no']]);
       });
+    });
+  });
+
+  describe('validator', () => {
+    [
+      {
+        title: 'undefined - empty',
+        given: () => ({
+          body: {},
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(1);
+          expect(result.errors[0].location).toEqual('body');
+          expect(result.errors[0].msg).toEqual('Select yes if you have told the other owners');
+          expect(result.errors[0].param).toEqual('have-other-owners-been-told');
+          expect(result.errors[0].value).toEqual(undefined);
+        },
+      },
+      {
+        title: 'invalid value for `have-other-owners-been-told` - fail',
+        given: () => ({
+          body: {
+            'have-other-owners-been-told': 91,
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(1);
+          expect(result.errors[0].location).toEqual('body');
+          expect(result.errors[0].msg).toEqual('Invalid value');
+          expect(result.errors[0].param).toEqual('have-other-owners-been-told');
+          expect(result.errors[0].value).toEqual(91);
+        },
+      },
+      {
+        title: 'valid value for `have-other-owners-been-told` - "yes" - pass',
+        given: () => ({
+          body: {
+            'have-other-owners-been-told': 'yes',
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(0);
+        },
+      },
+      {
+        title: 'valid value for `have-other-owners-been-told` - "no" - pass',
+        given: () => ({
+          body: {
+            'have-other-owners-been-told': 'no',
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(0);
+        },
+      },
+    ].forEach(({ title, given, expected }) => {
+      it(`should return the expected validation outcome - ${title}`, async () => {
+        const mockReq = given();
+        const mockRes = jest.fn();
+
+        await testExpressValidatorMiddleware(mockReq, mockRes, rules());
+        const result = validationResult(mockReq);
+        expected(result);
+      });
+    });
+  });
+
+  describe('validSiteOwnershipCertBOptions', () => {
+    it('should define the expected valid site ownership cert B options', () => {
+      expect(validSiteOwnershipCertBOptions).toEqual(['yes', 'no']);
     });
   });
 });


### PR DESCRIPTION
…radio buttons

## Ticket Number
<!-- Add the number from the Jira board -->
UCD-888

## Description of change
Corrects the logic that was forcing radio buttons to default to false if undefined or null on submit. 

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
