### PR TITLE
chore: remove http basic auth from prod cluster

### DIFF
--- a/clusters/prod/app.yml
+++ b/clusters/prod/app.yml
@@ -6,9 +6,9 @@ metadata:
   namespace: app-prod
   annotations:
     fluxcd.io/automated: "true"
-    filter.fluxcd.io/appealsServiceApi: semver:1.0.0
+    filter.fluxcd.io/appealsServiceApi: semver:1.2.0
     filter.fluxcd.io/documentServiceApi: semver:1.0.0
-    filter.fluxcd.io/formsWebApp: semver:1.0.0
+    filter.fluxcd.io/formsWebApp: semver:1.11.0
     filter.fluxcd.io/lpaQuestionnaireWebApp: semver:1.0.0
 spec:
   releaseName: app
@@ -38,7 +38,6 @@ spec:
         tag: 1.0.0
       config:
         enableLimitedRouting: true
-        googleAnalyticsId: G-RTYZW789M0
 
     lpaQuestionnaireWebApp:
       replicaCount: 2

--- a/clusters/prod/app.yml
+++ b/clusters/prod/app.yml
@@ -48,9 +48,6 @@ spec:
 
     keyVault:
       name: pins-uks-vault-8439-prod
-      envSpecific:
-        multiValueSecrets:
-        - http-basic
 
     ingress:
       hosts:
@@ -58,6 +55,3 @@ spec:
           host: appeal-planning-decision.planninginspectorate.gov.uk
         lpaq:
           host: lpa-questionnaire.planninginspectorate.gov.uk
-      httpBasic:
-        enabled: true
-        secret: akv-http-basic


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1428

## Description of change
<!-- Please describe the change -->
Removes the HTTP Basic password from the prod cluster. This is the last job to be done before we [push the button](https://www.youtube.com/watch?v=ZY3bcc-cKwo)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
