### PR TITLE
Revert "chore: disable http basic from dev"

### DIFF
--- a/clusters/dev/app.yml
+++ b/clusters/dev/app.yml
@@ -46,5 +46,5 @@ spec:
     ingress:
       host: appeals-dev.planninginspectorate.gov.uk
       httpBasic:
-        enabled: false
+        enabled: true
         secret: akv-http-basic


### PR DESCRIPTION
Reverts foundry4/appeal-planning-decision#338