### PR TITLE
feat(forms-web-app): extends the appeal for save and navigation feature

### DIFF
--- a/packages/forms-web-app/src/controllers/appellant-submission/appeal-statement.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/appeal-statement.js
@@ -2,7 +2,7 @@ const { VIEW } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { createDocument } = require('../../lib/documents-api-wrapper');
 const logger = require('../../lib/logger');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 const { getTaskStatus } = require('../../services/task.service');
 
 const sectionName = 'yourAppealSection';
@@ -61,5 +61,5 @@ exports.postAppealStatement = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/applicant-name.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/applicant-name.js
@@ -1,7 +1,7 @@
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
 const logger = require('../../lib/logger');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 const { getTaskStatus } = require('../../services/task.service');
 
 const sectionName = 'aboutYouSection';
@@ -44,5 +44,5 @@ exports.postApplicantName = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/application-number.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/application-number.js
@@ -1,7 +1,7 @@
 const { VIEW } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 const { getTaskStatus } = require('../../services/task.service');
 
 const sectionName = 'requiredDocumentsSection';
@@ -44,5 +44,5 @@ exports.postApplicationNumber = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/site-access-safety.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/site-access-safety.js
@@ -1,5 +1,5 @@
 const logger = require('../../lib/logger');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
 const { getTaskStatus } = require('../../services/task.service');
@@ -62,5 +62,5 @@ exports.postSiteAccessSafety = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/site-access.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/site-access.js
@@ -1,5 +1,5 @@
 const logger = require('../../lib/logger');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
 const { getTaskStatus } = require('../../services/task.service');
@@ -57,5 +57,5 @@ exports.postSiteAccess = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/site-location.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/site-location.js
@@ -1,7 +1,7 @@
 const { VIEW } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 const { getTaskStatus } = require('../../services/task.service');
 
 const sectionName = 'appealSiteSection';
@@ -48,5 +48,5 @@ exports.postSiteLocation = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/site-ownership-certb.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/site-ownership-certb.js
@@ -1,5 +1,5 @@
 const logger = require('../../lib/logger');
-const { getNextUncompletedTask, getTaskStatus } = require('../../services/task.service');
+const { getNextTask, getTaskStatus } = require('../../services/task.service');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
 const {
@@ -52,5 +52,5 @@ exports.postSiteOwnershipCertB = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/site-ownership.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/site-ownership.js
@@ -1,5 +1,5 @@
 const logger = require('../../lib/logger');
-const { getNextUncompletedTask, getTaskStatus } = require('../../services/task.service');
+const { getNextTask, getTaskStatus } = require('../../services/task.service');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
 const {
@@ -59,5 +59,5 @@ exports.postSiteOwnership = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/supporting-documents.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/supporting-documents.js
@@ -2,7 +2,7 @@ const { VIEW } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
 const { createDocument } = require('../../lib/documents-api-wrapper');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 const { getTaskStatus } = require('../../services/task.service');
 
 const sectionName = 'yourAppealSection';
@@ -41,7 +41,7 @@ exports.postSupportingDocuments = async (req, res) => {
       for await (const file of supportingDocuments) {
         const document = await createDocument(appeal, file);
 
-        appeal[sectionName][taskName].documents.push({
+        appeal[sectionName][taskName].uploadedFiles.push({
           id: document.id,
           name: file.name,
           // needed for MoJ multi-file upload display
@@ -68,5 +68,5 @@ exports.postSupportingDocuments = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/upload-application.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/upload-application.js
@@ -2,7 +2,7 @@ const { VIEW } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
 const { createDocument } = require('../../lib/documents-api-wrapper');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 const { getTaskStatus } = require('../../services/task.service');
 
 const sectionName = 'requiredDocumentsSection';
@@ -55,5 +55,5 @@ exports.postUploadApplication = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/upload-decision.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/upload-decision.js
@@ -3,7 +3,7 @@ const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
 const { createDocument } = require('../../lib/documents-api-wrapper');
 const { getTaskStatus } = require('../../services/task.service');
-const { getNextUncompletedTask } = require('../../services/task.service');
+const { getNextTask } = require('../../services/task.service');
 
 const sectionName = 'requiredDocumentsSection';
 const taskName = 'decisionLetter';
@@ -56,5 +56,5 @@ exports.postUploadDecision = async (req, res) => {
     return;
   }
 
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/controllers/appellant-submission/your-details.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/your-details.js
@@ -1,6 +1,6 @@
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
-const { getTaskStatus, getNextUncompletedTask } = require('../../services/task.service');
+const { getTaskStatus, getNextTask } = require('../../services/task.service');
 const { VIEW } = require('../../lib/views');
 
 const sectionName = 'aboutYouSection';
@@ -52,5 +52,5 @@ exports.postYourDetails = async (req, res) => {
     res.redirect(`/${VIEW.APPELLANT_SUBMISSION.APPLICANT_NAME}`);
     return;
   }
-  res.redirect(getNextUncompletedTask(appeal, { sectionName, taskName }).href);
+  res.redirect(getNextTask(appeal, { sectionName, taskName }).href);
 };

--- a/packages/forms-web-app/src/lib/empty-appeal.js
+++ b/packages/forms-web-app/src/lib/empty-appeal.js
@@ -35,7 +35,7 @@ module.exports.APPEAL_DOCUMENT = {
         hasSensitiveInformation: null,
       },
       otherDocuments: {
-        documents: [],
+        uploadedFiles: [],
       },
       otherAppeals: {},
     },

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -144,7 +144,7 @@ const getTaskStatus = (appeal, sectionName, taskName, sections = SECTIONS) => {
 };
 
 // Get next section task
-const getNextUncompletedTask = (appeal, currentTask, sections = SECTIONS) => {
+const getNextTask = (appeal, currentTask, sections = SECTIONS) => {
   const { sectionName, taskName } = currentTask;
 
   const section = sections[sectionName];
@@ -168,7 +168,7 @@ const getNextUncompletedTask = (appeal, currentTask, sections = SECTIONS) => {
       status,
       href: sections[sectionName][nextTaskName].href,
     };
-    if (![TASK_STATUS.COMPLETED, TASK_STATUS.CANNOT_START_YET].includes(nextTask.status)) {
+    if (TASK_STATUS.CANNOT_START_YET !== nextTask.status) {
       return nextTask;
     }
   }
@@ -179,5 +179,5 @@ const getNextUncompletedTask = (appeal, currentTask, sections = SECTIONS) => {
 module.exports = {
   SECTIONS,
   getTaskStatus,
-  getNextUncompletedTask,
+  getNextTask,
 };

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/appeal-statement.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/appeal-statement.test.js
@@ -3,7 +3,7 @@ const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrappe
 const { createDocument } = require('../../../../src/lib/documents-api-wrapper');
 const { mockReq, mockRes } = require('../../mocks');
 const logger = require('../../../../src/lib/logger');
-const { getNextUncompletedTask } = require('../../../../src/services/task.service');
+const { getNextTask } = require('../../../../src/services/task.service');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 const { getTaskStatus } = require('../../../../src/services/task.service');
 const { VIEW } = require('../../../../src/lib/views');
@@ -115,7 +115,7 @@ describe('controllers/appellant-submission/appeal-statement', () => {
       const fakeTaskStatus = 'FAKE_STATUS';
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.SUPPORTING_DOCUMENTS}`,
       });
 
@@ -166,7 +166,7 @@ describe('controllers/appellant-submission/appeal-statement', () => {
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
       createDocument.mockImplementation(() => ({ id: fakeFileId }));
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/applicant-name.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/applicant-name.test.js
@@ -2,7 +2,7 @@ const applicantNameController = require('../../../../src/controllers/appellant-s
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
-const { getTaskStatus, getNextUncompletedTask } = require('../../../../src/services/task.service');
+const { getTaskStatus, getNextTask } = require('../../../../src/services/task.service');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 const { mockReq, mockRes } = require('../../mocks');
 
@@ -101,7 +101,7 @@ describe('controllers/appellant-submission/applicant-name', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.TASK_LIST}`,
       });
       const mockRequest = {

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/application-number.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/application-number.test.js
@@ -4,7 +4,7 @@ const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrappe
 const logger = require('../../../../src/lib/logger');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 const { VIEW } = require('../../../../src/lib/views');
-const { getNextUncompletedTask, getTaskStatus } = require('../../../../src/services/task.service');
+const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/services/task.service');
@@ -92,7 +92,7 @@ describe('controllers/appellant-submission/application-number', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION}`,
       });
 

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-access-safety.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-access-safety.test.js
@@ -2,7 +2,7 @@ const siteAccessSafetyController = require('../../../../src/controllers/appellan
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
-const { getNextUncompletedTask } = require('../../../../src/services/task.service');
+const { getNextTask } = require('../../../../src/services/task.service');
 const { mockReq, mockRes } = require('../../mocks');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 const { getTaskStatus } = require('../../../../src/services/task.service');
@@ -91,7 +91,7 @@ describe('controllers/appellant-submission/site-access-safety', () => {
       const fakeTaskStatus = 'FAKE_STATUS';
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.TASK_LIST}`,
       });
       const mockRequest = {
@@ -147,7 +147,7 @@ describe('controllers/appellant-submission/site-access-safety', () => {
         const fakeTaskStatus = 'ANOTHER_FAKE_STATUS';
         getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-        getNextUncompletedTask.mockReturnValue({
+        getNextTask.mockReturnValue({
           href: `/${VIEW.APPELLANT_SUBMISSION.TASK_LIST}`,
         });
         const mockRequest = {

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-access.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-access.test.js
@@ -2,7 +2,7 @@ const siteAccessController = require('../../../../src/controllers/appellant-subm
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
-const { getNextUncompletedTask, getTaskStatus } = require('../../../../src/services/task.service');
+const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 const { mockReq, mockRes } = require('../../mocks');
 
@@ -92,7 +92,7 @@ describe('controllers/appellant-submission/site-access', () => {
 
     it('should redirect to `/appellant-submission/site-access-safety` if `site-access` is `yes`', async () => {
       createOrUpdateAppeal.mockImplementation(() => JSON.stringify({ good: 'data' }));
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.SITE_ACCESS_SAFETY}`,
       });
       const mockRequest = {
@@ -120,7 +120,7 @@ describe('controllers/appellant-submission/site-access', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.SITE_ACCESS_SAFETY}`,
       });
       const mockRequest = {

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-location.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-location.test.js
@@ -2,7 +2,7 @@ const siteLocationController = require('../../../../src/controllers/appellant-su
 const { mockReq, mockRes } = require('../../mocks');
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const logger = require('../../../../src/lib/logger');
-const { getNextUncompletedTask, getTaskStatus } = require('../../../../src/services/task.service');
+const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 const { VIEW } = require('../../../../src/lib/views');
 
@@ -100,7 +100,7 @@ describe('controllers/appellant-submission/site-location', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: `/${VIEW.APPELLANT_SUBMISSION.SITE_OWNERSHIP}`,
       });
       const mockRequest = {

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-ownership-certb.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-ownership-certb.test.js
@@ -2,7 +2,7 @@ const siteOwnershipCertBController = require('../../../../src/controllers/appell
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
-const { getNextUncompletedTask, getTaskStatus } = require('../../../../src/services/task.service');
+const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 const { mockReq, mockRes } = require('../../mocks');
 
@@ -96,7 +96,7 @@ describe('controllers/appellant-submission/site-ownership-certb', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-ownership.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/site-ownership.test.js
@@ -2,7 +2,7 @@ const siteOwnershipController = require('../../../../src/controllers/appellant-s
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
-const { getNextUncompletedTask, getTaskStatus } = require('../../../../src/services/task.service');
+const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 const { mockReq, mockRes } = require('../../mocks');
 
@@ -94,7 +94,7 @@ describe('controllers/appellant-submission/site-ownership', () => {
       const fakeTaskStatus = 'FAKE_STATUS';
       const fakeNextUrl = `/next/valid/url`;
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 
@@ -167,7 +167,7 @@ describe('controllers/appellant-submission/site-ownership', () => {
       });
 
       expect(logger.error).not.toHaveBeenCalled();
-      expect(getNextUncompletedTask).not.toHaveBeenCalledWith();
+      expect(getNextTask).not.toHaveBeenCalledWith();
 
       expect(res.redirect).toHaveBeenCalledWith(
         `/${VIEW.APPELLANT_SUBMISSION.SITE_OWNERSHIP_CERTB}`
@@ -179,7 +179,7 @@ describe('controllers/appellant-submission/site-ownership', () => {
     it('should null the contents of haveOtherOwnersBeenTold if site-ownership is set to yes', async () => {
       const fakeTaskStatus = 'FAKE_STATUS';
 
-      getNextUncompletedTask.mockReturnValue({ href: '/some/path' });
+      getNextTask.mockReturnValue({ href: '/some/path' });
       getTaskStatus.mockReturnValue(fakeTaskStatus);
 
       const mockRequest = {
@@ -219,7 +219,7 @@ describe('controllers/appellant-submission/site-ownership', () => {
     it('should retain the contents of haveOtherOwnersBeenTold if site-ownership is set to no', async () => {
       const fakeTaskStatus = 'FAKE_STATUS';
 
-      getNextUncompletedTask.mockReturnValue({ href: '/some/path' });
+      getNextTask.mockReturnValue({ href: '/some/path' });
       getTaskStatus.mockReturnValue(fakeTaskStatus);
 
       const mockRequest = {

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/supporting-documents.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/supporting-documents.test.js
@@ -3,7 +3,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const logger = require('../../../../src/lib/logger');
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const { createDocument } = require('../../../../src/lib/documents-api-wrapper');
-const { getNextUncompletedTask, getTaskStatus } = require('../../../../src/services/task.service');
+const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
 const { VIEW } = require('../../../../src/lib/views');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 
@@ -60,7 +60,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
           [sectionName]: {
             ...req.session.appeal[sectionName],
             [taskName]: {
-              documents: [],
+              uploadedFiles: [],
             },
           },
         },
@@ -99,7 +99,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 
@@ -125,7 +125,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
       createDocument.mockImplementation(() => ({ id: fakeFileId }));
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 
@@ -145,7 +145,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
         [sectionName]: {
           ...appeal[sectionName],
           [taskName]: {
-            documents: [
+            uploadedFiles: [
               {
                 fileName: fakeFileName,
                 id: fakeFileId,
@@ -190,7 +190,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
         .mockImplementationOnce(() => ({ id: fakeFile1Id }))
         .mockImplementationOnce(() => ({ id: fakeFile2Id }));
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 
@@ -215,7 +215,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
         [sectionName]: {
           ...appeal[sectionName],
           [taskName]: {
-            documents: [
+            uploadedFiles: [
               {
                 fileName: fakeFile1Name,
                 id: fakeFile1Id,

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/upload-application.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/upload-application.test.js
@@ -3,7 +3,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const logger = require('../../../../src/lib/logger');
 const { createDocument } = require('../../../../src/lib/documents-api-wrapper');
-const { getNextUncompletedTask, getTaskStatus } = require('../../../../src/services/task.service');
+const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
 const { VIEW } = require('../../../../src/lib/views');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 
@@ -102,7 +102,7 @@ describe('controllers/appellant-submission/upload-application', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 
@@ -128,7 +128,7 @@ describe('controllers/appellant-submission/upload-application', () => {
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
       createDocument.mockImplementation(() => ({ id: fakeFileId }));
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/upload-decision.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/upload-decision.test.js
@@ -3,7 +3,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const logger = require('../../../../src/lib/logger');
 const { createDocument } = require('../../../../src/lib/documents-api-wrapper');
-const { getNextUncompletedTask, getTaskStatus } = require('../../../../src/services/task.service');
+const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
 const { VIEW } = require('../../../../src/lib/views');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
 
@@ -103,7 +103,7 @@ describe('controllers/appellant-submission/upload-decision', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 
@@ -148,7 +148,7 @@ describe('controllers/appellant-submission/upload-decision', () => {
 
       createDocument.mockImplementation(() => ({ id: fakeFileId }));
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/your-details.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/your-details.test.js
@@ -4,7 +4,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
 const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
-const { getTaskStatus, getNextUncompletedTask } = require('../../../../src/services/task.service');
+const { getTaskStatus, getNextTask } = require('../../../../src/services/task.service');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/services/task.service');
@@ -100,7 +100,7 @@ describe('controllers/appellant-submission/your-details', () => {
 
       getTaskStatus.mockImplementation(() => fakeTaskStatus);
 
-      getNextUncompletedTask.mockReturnValue({
+      getNextTask.mockReturnValue({
         href: fakeNextUrl,
       });
 
@@ -194,7 +194,7 @@ describe('controllers/appellant-submission/your-details', () => {
 
       expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.APPELLANT_SUBMISSION.APPLICANT_NAME}`);
 
-      expect(getNextUncompletedTask).not.toHaveBeenCalled();
+      expect(getNextTask).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/forms-web-app/tests/unit/services/task.service.test.js
+++ b/packages/forms-web-app/tests/unit/services/task.service.test.js
@@ -7,11 +7,11 @@ const {
   NOT_STARTED,
 } = require('../../../src/services/task-status/task-statuses');
 
-const { SECTIONS, getNextUncompletedTask } = require('../../../src/services/task.service');
+const { SECTIONS, getNextTask } = require('../../../src/services/task.service');
 
 describe('services/task.service', () => {
   describe('getNextTask', () => {
-    it('should return next uncompleted task', async () => {
+    it('should return next on going task', async () => {
       const appeal = {
         sectionStates: {
           Section1: {
@@ -23,34 +23,34 @@ describe('services/task.service', () => {
         },
       };
 
-      const task = getNextUncompletedTask(
+      const task = getNextTask(
         appeal,
         {
           sectionName: 'Section1',
-          taskName: 'Task2',
+          taskName: 'Task1',
         },
         appeal.sectionStates
       );
 
-      expect(task.taskName).toEqual('Task4');
+      expect(task.taskName).toEqual('Task3');
     });
-    it('should return task list as all the section tasks are completed', async () => {
+    it('should return task list as all the remaining section tasks cannot be started yet', async () => {
       const appeal = {
         sectionStates: {
           Section1: {
             Task1: IN_PROGRESS,
-            Task2: COMPLETED,
-            Task3: COMPLETED,
-            Task4: COMPLETED,
+            Task2: CANNOT_START_YET,
+            Task3: CANNOT_START_YET,
+            Task4: CANNOT_START_YET,
           },
         },
       };
 
-      const task = getNextUncompletedTask(
+      const task = getNextTask(
         appeal,
         {
           sectionName: 'Section1',
-          taskName: 'Task2',
+          taskName: 'Task1',
         },
         appeal.sectionStates
       );
@@ -67,7 +67,7 @@ describe('services/task.service', () => {
     });
   });
 
-  describe('getNextUncompletedTask', () => {
+  describe('getNextTask', () => {
     [
       {
         appeal: {
@@ -103,9 +103,9 @@ describe('services/task.service', () => {
           sectionStates: {
             Section1: {
               Task1: IN_PROGRESS,
-              Task2: COMPLETED,
-              Task3: COMPLETED,
-              Task4: COMPLETED,
+              Task2: CANNOT_START_YET,
+              Task3: CANNOT_START_YET,
+              Task4: CANNOT_START_YET,
             },
           },
         },
@@ -133,8 +133,8 @@ describe('services/task.service', () => {
         expected: { href: undefined, status: IN_PROGRESS, taskName: 'Task2' },
       },
     ].forEach(({ appeal, currentTask, expected }) => {
-      it('should return the expected next uncompleted task', () => {
-        expect(getNextUncompletedTask(appeal, currentTask, appeal.sectionStates)).toEqual(expected);
+      it('should return the expected next on going task', () => {
+        expect(getNextTask(appeal, currentTask, appeal.sectionStates)).toEqual(expected);
       });
     });
 
@@ -144,7 +144,7 @@ describe('services/task.service', () => {
         sectionName: 'aboutYouSection',
         taskName: 'yourDetails',
       };
-      expect(getNextUncompletedTask(appeal, currentTask)).toEqual({
+      expect(getNextTask(appeal, currentTask)).toEqual({
         href: '/appellant-submission/task-list',
       });
     });
@@ -167,7 +167,7 @@ describe('services/task.service', () => {
         sectionName: 'requiredDocumentsSection',
         taskName: 'applicationNumber',
       };
-      expect(getNextUncompletedTask(appeal, currentTask)).toEqual({
+      expect(getNextTask(appeal, currentTask)).toEqual({
         href: '/appellant-submission/upload-application',
         status: NOT_STARTED,
         taskName: 'originalApplication',


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-754

## Description of change
<!-- Please describe the change -->
Extends the appeal for save and navigation feature : 
We are only skipping CANNOT START YET tasks while redirection and not COMPLETED as it used to be.
## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
