### PR TITLE
fix(healthchecks): configure forms web app for /health endpoint

### DIFF
--- a/charts/app/templates/formsWebApp.yaml
+++ b/charts/app/templates/formsWebApp.yaml
@@ -42,11 +42,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: {{.Values.formsWebApp.service.name }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: {{.Values.formsWebApp.service.name }}
           env:
             - name: APPEALS_SERVICE_API_URL

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -100,6 +100,8 @@ ingress:
     secret: ""
   clusterIssuer: letsencrypt
   redirects:
+    - path: /health
+      target: /display-404
     - path: /metrics
       target: /display-404
 

--- a/packages/forms-web-app/src/lib/healthchecks.js
+++ b/packages/forms-web-app/src/lib/healthchecks.js
@@ -1,0 +1,9 @@
+const { healthcheck } = require('@pins/common');
+const logger = require('./logger');
+
+module.exports = (server) =>
+  healthcheck({
+    server,
+    logger,
+    tasks: [],
+  });

--- a/packages/forms-web-app/src/server.js
+++ b/packages/forms-web-app/src/server.js
@@ -7,6 +7,7 @@ const http = require('http');
 const config = require('./config.js');
 const app = require('./app.js');
 const logger = require('./lib/logger');
+const healthChecks = require('./lib/healthchecks');
 
 /**
  * Get port from environment and store in Express.
@@ -18,6 +19,12 @@ app.set('port', port);
  * Create HTTP server.
  */
 const server = http.createServer(app);
+
+/**
+ * Add healthchecks
+ */
+
+healthChecks(server);
 
 /**
  * Event listener for HTTP server "error" event.

--- a/packages/forms-web-app/tests/unit/lib/healthchecks.test.js
+++ b/packages/forms-web-app/tests/unit/lib/healthchecks.test.js
@@ -1,0 +1,19 @@
+jest.mock('@pins/common');
+
+const common = require('@pins/common');
+const logger = require('../../../src/lib/logger');
+const healthchecks = require('../../../src/lib/healthchecks');
+
+describe('healthchecks', () => {
+  it('should configure the health checks', () => {
+    const server = jest.fn();
+
+    expect(healthchecks(server)).toBe(undefined);
+
+    expect(common.healthcheck).toBeCalledWith({
+      server,
+      logger,
+      tasks: [],
+    });
+  });
+});


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1453

## Description of change
<!-- Please describe the change -->
Change k8s so we use a health check for the forms web app, rather than the homepage. The ingress controller is configured so as to not publicly expose the /health endpoint (as per the /metrics).

The reason for this change is to avoid lots of spurious data being collected in Google Analytics

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
