### PR TITLE
test(e2e-tests): confirm that no answer is selected by default in acc…

### DIFF
--- a/e2e-tests/cypress/integration/appeal-submission-access-to-appeal-site.feature
+++ b/e2e-tests/cypress/integration/appeal-submission-access-to-appeal-site.feature
@@ -11,7 +11,7 @@ I want to notify the Planning Inspectorate if access to the appeal site is restr
       When the user selects "No" to provide access
       And the user "does not" provide additional information
       Then the user is informed that "further information is required to gain access to the restricted site"
-      And the user can see the selected option "is not" submitted
+      And the user can see that there is no option submitted
 
     Scenario: Prospective appellant provide additional information on restricted access to the appeal site
       Given the user is prompted to provide access to the inspector visiting the appeal site
@@ -24,12 +24,13 @@ I want to notify the Planning Inspectorate if access to the appeal site is restr
       When the user selects "No" to provide access
       And the user does provide additional information with character length exceeding the limit
       Then the user is told "How access is restricted must be 255 characters or less"
-      And the user can see the selected option "is not" submitted
+      And the user can see that there is no option submitted
 
     Scenario: Prospective appellant does not select any option to provide access to the appeal site
       Given the user is prompted to provide access to the inspector visiting the appeal site
       When the user does not select any option
       Then the user is told "Select Yes if the appeal site can be seen from a public road"
+      And the user can see that there is no option submitted
 
 
 

--- a/e2e-tests/cypress/integration/appeal-submission-access-to-appeal-site/appeal-submission-access-to-appeal-site.js
+++ b/e2e-tests/cypress/integration/appeal-submission-access-to-appeal-site/appeal-submission-access-to-appeal-site.js
@@ -30,17 +30,17 @@ When('the user {string} provide additional information', (provided) => {
 });
 
 Then('the user can see the selected option {string} submitted', (submitted) => {
-  if (submitted === 'is not') {
-    cy.confirmAccessSiteNotSubmitted();
+  if (submitted.includes('Yes')) {
+    cy.confirmAccessSiteAnswered('yes');
+  } else if (submitted.includes('No')) {
+    cy.confirmAccessSiteAnswered('no', 'More information');
   } else {
-    if (submitted.includes('Yes')) {
-      cy.confirmAccessSiteAnswered('yes');
-    } else if (submitted.includes('No')) {
-      cy.confirmAccessSiteAnswered('no', 'More information');
-    } else {
-      throw new Error('unknown selected option');
-    }
+    throw new Error('unknown selected option');
   }
+});
+
+Then('the user can see that there is no option submitted', () => {
+  cy.confirmAccessSiteNotSubmitted();
 });
 
 Then('the user is informed that {string}', (reason) => {


### PR DESCRIPTION

## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1362

## Description of change
<!-- Please describe the change -->
confirm that no answer is selected by default in access safety
## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
