### PR TITLE
chore: remove first cypress test we wrote, it is old and flakey

### DIFF
--- a/e2e-tests/cypress/integration/eligibility-decision-date-page-components.feature
+++ b/e2e-tests/cypress/integration/eligibility-decision-date-page-components.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: The Decision Date page has the right structure
     I need to provide the date of the decision from the local planning department,
     so that the system can confirm whether my appeal is in time.


### PR DESCRIPTION
## Ticket Number
UCD-?

## Description of change

This test had a date hard coded in it, and that date started to fail.
This test is legacy; it is the first test we ever wrote, it is entirely UI focussed and has been superseded.
In the meantime, it's existence is causing public failures of things that shouldn't be failing, it's time has come.

need a follow up to remove the feature+glue altogether, this PR will stop the flakey test failing.



## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
