### PR TITLE
chore: remove first cypress test we wrote, it is old and flakey

### DIFF
--- a/e2e-tests/cypress/integration/eligibility-decision-date-page-components.feature
+++ b/e2e-tests/cypress/integration/eligibility-decision-date-page-components.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: The Decision Date page has the right structure
     I need to provide the date of the decision from the local planning department,
     so that the system can confirm whether my appeal is in time.


### PR DESCRIPTION
## Ticket Number
UCD-?

## Description of change
Remove the first cypress test we ever wrote.
It has a date hard-coded in it; the date has become important and the test has started failing
It is a bad test; it is totally UI focussed and should have been removed by now.
@wip ing it now so that other work can proceed without this test failure getting in the way
will add ticket to backlog to properly remove feature+glue

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
