### PR TITLE
Feature/as 28 appeals data panel

### DIFF
--- a/data/data/appeals-service-api/001-appeals.json
+++ b/data/data/appeals-service-api/001-appeals.json
@@ -1,1 +1,99 @@
-[]
+[
+  {
+    "_id": "89aa8504-773c-42be-bb68-029716ad9756",
+    "uuid": "89aa8504-773c-42be-bb68-029716ad9756",
+    "appeal": {
+      "sectionStates": {
+        "aboutYouSection": {
+          "yourDetails": "COMPLETED"
+        },
+        "requiredDocumentsSection": {
+          "applicationNumber": "COMPLETED",
+          "originalApplication": "NOT STARTED",
+          "decisionLetter": "NOT STARTED"
+        },
+        "yourAppealSection": {
+          "appealStatement": "NOT STARTED",
+          "otherDocuments": "NOT STARTED",
+          "otherAppeals": "NOT STARTED"
+        },
+        "appealSiteSection": {
+          "siteAccess": "COMPLETED",
+          "siteOwnership": "COMPLETED",
+          "healthAndSafety": "COMPLETED",
+          "siteAddress": "COMPLETED"
+        }
+      },
+      "appealSiteSection": {
+        "healthAndSafety": {
+          "hasIssues": false,
+          "healthAndSafetyIssues": ""
+        },
+        "siteAccess": {
+          "howIsSiteAccessRestricted": "",
+          "canInspectorSeeWholeSiteFromPublicRoad": true
+        },
+        "siteOwnership": {
+          "ownsWholeSite": true,
+          "haveOtherOwnersBeenTold": null
+        },
+        "siteAddress": {
+          "addressLine1": "999 Letsby Avenue",
+          "addressLine2": "",
+          "town": "Sheffield",
+          "county": "South Yorkshire",
+          "postcode": "S9 1XY"
+        }
+      },
+      "yourAppealSection": {
+        "appealStatement": {
+          "uploadedFile": {
+            "id": "e4cb9e13-90ad-4c1e-b339-fb0803c2b064",
+            "name": "Birthday-Quiz.pdf",
+            "location": "e8e8124217d256a7cb03a6410f9f3d10",
+            "size": 429927
+          },
+          "hasSensitiveInformation": false
+        },
+        "otherDocuments": {
+          "uploadedFiles": []
+        },
+        "otherAppeals": {
+          "hasOtherAppeal": null,
+          "otherAppealRefNumber": ""
+        }
+      },
+      "requiredDocumentsSection": {
+        "applicationNumber": "ABC/123",
+        "originalApplication": {
+          "uploadedFile": {
+            "id": "61024954-2dd7-41c2-95ea-0fc2e35fa9bb",
+            "name": "attinghamparkbees.jpg",
+            "location": "0d6f62cf1fa8d0797060e5eb6b8dad8f",
+            "size": 189549
+          }
+        },
+        "decisionLetter": {
+          "uploadedFile": {
+            "id": "59c55221-ddaa-4ef8-ba48-c2570b3418e8",
+            "name": "attinghamparkbees.jpg",
+            "location": "36d62a0dcb32c3648c8b0f023383464f",
+            "size": 189549
+          }
+        }
+      },
+      "aboutYouSection": {
+        "yourDetails": {
+          "appealingOnBehalfOf": "",
+          "email": "bob@smith.com",
+          "name": "Bob Smith",
+          "isOriginalApplicant": true
+        }
+      },
+      "state": "DRAFT",
+      "decisionDate": "2021-01-01T12:00:00Z",
+      "lpaCode": "E60000068",
+      "id": "89aa8504-773c-42be-bb68-029716ad9756"
+    }
+  }
+]

--- a/lpa-submissions-e2e-tests/cypress/integration/appealDetailsSidebar.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealDetailsSidebar.feature
@@ -1,0 +1,27 @@
+Feature: appealDetailsSidebar:
+  As an LPA user I want to know which planning application I am responding on
+  so that I provide the correct information to the Planning Inspectorate.
+
+  The user should be able to see the following data relating to the appeal:
+
+  Planning application number
+  Site address
+  Apellant Name
+
+  Scenario Outline: AC1-Appeal details sidebar is displayed with the correct information
+    Given A subsection page is presented with id of <id>
+    Then The appeal details sidebar is displayed with the heading "Planning application number", "Site address", and "Appellant Name"
+    And The <application-number>, <address>, and <apellant-name> is displayed
+    Examples:
+      | id                                     | application-number   | address                                                 | apellant-name   |
+      | "89aa8504-773c-42be-bb68-029716ad9756" | "ABC/123"            | "999 Letsby Avenue, Sheffield, South Yorkshire, S9 1XY" | "Bob Smith"     |
+
+  Scenario Outline: Appeal details sidebar not shown if invalid ID is provided
+    Given A subsection page is presented with id of <id>
+    Then The appeal sidebar is not displayed
+    Examples:
+      | id                                     |
+      | " "                                    |
+      | "invalidId"                            |
+      | "89aa8504 773c 42be bb68 029716ad9756" |
+      | "89aa8504/773c/42be/bb68/029716ad9756" |

--- a/lpa-submissions-e2e-tests/cypress/integration/appealDetailsSidebar/appealDetailsSidebarSteps.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealDetailsSidebar/appealDetailsSidebarSteps.js
@@ -1,0 +1,26 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
+
+Given("A subsection page is presented with id of {string}", (id)=> {
+  cy.goToTellUsAboutAppealsInImmediateAreaPage(id);
+});
+
+Then('The appeal details sidebar is displayed with the heading "Planning application number", "Site address", and "Appellant Name"', () => {
+  cy.getAppealDetailsSidebar()
+    .then(text => {
+      expect(text).to.contain('Planning application number');
+      expect(text).to.contain('Site address');
+      expect(text).to.contain('Appellant Name');
+    });
+});
+
+Then('The {string}, {string}, and {string} is displayed', (applicationNumber, applicationAddress, apellantName) => {
+  cy.verifyAppealDetailsSidebar({
+    applicationNumber,
+    applicationAddress,
+    apellantName,
+  });
+});
+
+Then('The appeal sidebar is not displayed', () => {
+  cy.getAppealDetailsSidebar().should('not.exist');
+});

--- a/lpa-submissions-e2e-tests/cypress/support/PageObjects/AppealDetailsPageObjects.js
+++ b/lpa-submissions-e2e-tests/cypress/support/PageObjects/AppealDetailsPageObjects.js
@@ -1,0 +1,19 @@
+class AppealDetailsSidebar {
+  getAppealDetailsSidebar() {
+    return cy.get('[data-cy="appealDetails"]');
+  }
+
+  getPlanningApplicationNumber() {
+    return cy.get('[data-cy="planningApplicationNumber"]');
+  }
+
+  getPlanningApplicationAddress() {
+    return cy.get('[data-cy="planningApplicationAddress"]');
+  }
+
+  getPlanningApplicationAppellant() {
+    return cy.get('[data-cy="planningApplicationApellant"]');
+  }
+}
+
+export default AppealDetailsSidebar;

--- a/lpa-submissions-e2e-tests/cypress/support/PageObjects/appeals-questionnaire-tasklist-pageobjects.js
+++ b/lpa-submissions-e2e-tests/cypress/support/PageObjects/appeals-questionnaire-tasklist-pageobjects.js
@@ -7,7 +7,6 @@ class AppealsQuestionnaireTaskList {
     return cy.get('a[data-cy="extraConditions"]');
   }
 
-
   getAreaAppeals(){
     return cy.get('a[data-cy="areaAppeals"]');
   }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToDevelopmentPlanDocumentOrNeighbourhoodPlanPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToDevelopmentPlanDocumentOrNeighbourhoodPlanPage.js
@@ -1,9 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
-const tasklist = new AppealsQuestionnaireTaskList()
- module.exports = () =>{
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
+
+module.exports = (id = defaultPathId) => {
   tasklist.getDevelopmentOrNeighbourhood().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToExtraConditionsPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToExtraConditionsPage.js
@@ -1,10 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
 
-module.exports = () =>{
+module.exports = (id = defaultPathId) => {
   tasklist.getExtraConditions().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
-//  cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToNotifyingInterestedPartiesOfTheAppealPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToNotifyingInterestedPartiesOfTheAppealPage.js
@@ -1,10 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
 
- module.exports = () =>{
-   tasklist.getInterestedPartiesAppeal().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+module.exports = (id = defaultPathId) => {
+  tasklist.getInterestedPartiesAppeal().click();
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToOtherRelevantPoliciesPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToOtherRelevantPoliciesPage.js
@@ -1,10 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
 
- module.exports = () =>{
-   tasklist.getOtherPolicies().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+module.exports = (id = defaultPathId) => {
+  tasklist.getOtherPolicies().click();
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToPlanningHistoryPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToPlanningHistoryPage.js
@@ -1,10 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
 
- module.exports = () =>{
+module.exports = (id = defaultPathId) => {
   tasklist.getPlanningHistory().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToRepresentationsFromInterestedPartiesPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToRepresentationsFromInterestedPartiesPage.js
@@ -1,10 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
 
-module.exports = () =>{
+module.exports = (id = defaultPathId) => {
   tasklist.getRepresentationsInterestedParties().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToReviewAccuracyOfTheAppellantsSubmissionPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToReviewAccuracyOfTheAppellantsSubmissionPage.js
@@ -1,9 +1,10 @@
  /// <reference types = "Cypress"/>
+import defaultPathId from '../../utils/defaultPathId';
 import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
-const tasklist = new AppealsQuestionnaireTaskList()
-module.exports = () =>{
+const tasklist = new AppealsQuestionnaireTaskList();
 
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+module.exports = (id = defaultPathId) => {
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToSiteNoticesPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToSiteNoticesPage.js
@@ -1,9 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
-module.exports = () =>{
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
+
+module.exports = (id = defaultPathId) => {
   tasklist.getSiteNotices().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
-//  cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToStatutoryDevelopmentPlanPolicyPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToStatutoryDevelopmentPlanPolicyPage.js
@@ -1,9 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
- module.exports = () =>{
-   tasklist.getStatutoryDevelopment().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
+
+module.exports = (id = defaultPathId) => {
+  tasklist.getStatutoryDevelopment().click();
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToSupplementaryPlanningDocumentsExtractPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToSupplementaryPlanningDocumentsExtractPage.js
@@ -1,9 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
- module.exports = () =>{
-   tasklist.getSupplementaryPlanningDocuments().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
-//  cy.checkA11y(path)
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList()
+
+module.exports = (id = defaultPathId) => {
+  tasklist.getSupplementaryPlanningDocuments().click();
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToTellUsAboutAppealSitePage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToTellUsAboutAppealSitePage.js
@@ -1,9 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
-module.exports = () =>{
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
+
+module.exports = (id = defaultPathId) => {
   tasklist.getAboutSite().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToTellUsAboutAppealsInImmediateAreaPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToTellUsAboutAppealsInImmediateAreaPage.js
@@ -1,9 +1,8 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
-module.exports = () =>{
-  tasklist.getAreaAppeals().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
-//  cy.checkA11y(path)
+import defaultPathId from '../../utils/defaultPathId';
+
+module.exports = (id = defaultPathId) => {
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToTellingInterestedPartiesAboutTheApplicationPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToTellingInterestedPartiesAboutTheApplicationPage.js
@@ -1,9 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
-module.exports = () =>{
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
+
+module.exports = (id = defaultPathId) => {
   tasklist.getInterestedPartiesApplication().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToUploadPlanningOfficersReportPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToUploadPlanningOfficersReportPage.js
@@ -1,9 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
-module.exports = () =>{
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
+
+module.exports = (id = defaultPathId) => {
   tasklist.getOfficersReport().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
- // cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  // cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToUploadThePlansUsedToReachDecisionPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-navigation/goToUploadThePlansUsedToReachDecisionPage.js
@@ -1,9 +1,11 @@
  /// <reference types = "Cypress"/>
- import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
- const tasklist = new AppealsQuestionnaireTaskList()
-module.exports = () =>{
+import defaultPathId from '../../utils/defaultPathId';
+import AppealsQuestionnaireTaskList from '../PageObjects/appeals-questionnaire-tasklist-pageobjects';
+const tasklist = new AppealsQuestionnaireTaskList();
+
+module.exports = (id = defaultPathId) => {
   tasklist.getPlansDecision().click();
-  let path = 'appeals-questionnaire/placeholder'
-  cy.visit(path, {failOnStatusCode:false})
-  //cy.checkA11y(path)
+  const path = `/${id}/placeholder`;
+  cy.visit(path, {failOnStatusCode:false});
+  //cy.checkA11y(path);
 }

--- a/lpa-submissions-e2e-tests/cypress/support/commands.js
+++ b/lpa-submissions-e2e-tests/cypress/support/commands.js
@@ -90,3 +90,9 @@ require('./appeals-questionnaire-navigation/checkYourAnswers'));
 
 Cypress.Commands.add('verifyCannotStartStatus',
 require('./appeals-questionnaire-navigation/verifyCannotStartStatus'));
+
+Cypress.Commands.add('verifyAppealDetailsSidebar',
+require('./common/verifyAppealDetailsSidebar'));
+
+Cypress.Commands.add('getAppealDetailsSidebar',
+require('./common/getAppealDetailsSidebar'));

--- a/lpa-submissions-e2e-tests/cypress/support/common/getAppealDetailsSidebar.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/getAppealDetailsSidebar.js
@@ -1,0 +1,7 @@
+import AppealDetails from '../PageObjects/AppealDetailsPageObjects';
+
+const appealDetails = new AppealDetails()
+
+module.exports = () => {
+  appealDetails.getAppealDetailsSidebar();
+}

--- a/lpa-submissions-e2e-tests/cypress/support/common/verifyAppealDetailsSidebar.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/verifyAppealDetailsSidebar.js
@@ -1,0 +1,15 @@
+import AppealDetails from '../PageObjects/AppealDetailsPageObjects';
+
+const appealDetails = new AppealDetails()
+
+module.exports = ({ applicationNumber, applicationAddress, apellantName }) => {
+  appealDetails
+    .getPlanningApplicationNumber()
+    .contains(applicationNumber);
+  appealDetails
+    .getPlanningApplicationAddress()
+    .contains(applicationAddress);
+  appealDetails
+    .getPlanningApplicationAppellant()
+    .contains(apellantName);
+}

--- a/lpa-submissions-e2e-tests/cypress/utils/defaultPathId.js
+++ b/lpa-submissions-e2e-tests/cypress/utils/defaultPathId.js
@@ -1,0 +1,1 @@
+module.exports = '89aa8504-773c-42be-bb68-029716ad9756';

--- a/packages/lpa-questionnaire-web-app/src/controllers/index.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/index.js
@@ -1,5 +1,5 @@
 const { VIEW } = require('../lib/views');
 
 exports.getIndex = (req, res) => {
-  res.redirect(`/${VIEW.TASK_LIST}`);
+  res.redirect(`/${req.params.id}/${VIEW.TASK_LIST}`);
 };

--- a/packages/lpa-questionnaire-web-app/src/controllers/placeholder.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/placeholder.js
@@ -1,5 +1,8 @@
 const { VIEW } = require('../lib/views');
+const getAppealSideBarDetails = require('../lib/appeal-sidebar-details');
 
-exports.getPlaceholder = (_, res) => {
-  res.render(VIEW.PLACEHOLDER);
+exports.getPlaceholder = (req, res) => {
+  res.render(VIEW.PLACEHOLDER, {
+    appeal: getAppealSideBarDetails(req.session.appeal),
+  });
 };

--- a/packages/lpa-questionnaire-web-app/src/controllers/task-list.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/task-list.js
@@ -7,7 +7,7 @@ const { VIEW } = require('../lib/views');
  * @param questionnaire Questionnaire details from request
  * @return {array} Array of section objects
  */
-function buildTaskLists(questionnaire) {
+function buildTaskLists(questionnaire, appealId) {
   return SECTIONS.map(({ sectionId, tasks }) => {
     return {
       heading: {
@@ -22,7 +22,7 @@ function buildTaskLists(questionnaire) {
 
         return {
           text: HEADERS[taskId],
-          href,
+          href: `/${appealId}${href}`,
           attributes: {
             name: taskId,
             [`${taskId}-status`]: status,
@@ -36,7 +36,7 @@ function buildTaskLists(questionnaire) {
 
 exports.getTaskList = (req, res) => {
   const { questionnaire } = req.session;
-  const sections = buildTaskLists(questionnaire);
+  const sections = buildTaskLists(questionnaire, req.params.id);
   const applicationStatus = 'Application incomplete';
 
   res.render(VIEW.TASK_LIST, {

--- a/packages/lpa-questionnaire-web-app/src/lib/appeal-sidebar-details.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/appeal-sidebar-details.js
@@ -1,0 +1,17 @@
+const formatAddress = (address) => {
+  const addressFields = Object.values(address).filter((value) => !!value);
+  return addressFields.join(', ');
+};
+
+module.exports = (appeal) => {
+  if (!appeal) return null;
+
+  return {
+    number: appeal.requiredDocumentsSection && appeal.requiredDocumentsSection.applicationNumber,
+    address: appeal.appealSiteSection && formatAddress(appeal.appealSiteSection.siteAddress),
+    appellant:
+      appeal.aboutYouSection &&
+      appeal.aboutYouSection.yourDetails &&
+      appeal.aboutYouSection.yourDetails.name,
+  };
+};

--- a/packages/lpa-questionnaire-web-app/src/lib/appeals-api-wrapper.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/appeals-api-wrapper.js
@@ -1,0 +1,50 @@
+const fetch = require('node-fetch');
+const uuid = require('uuid');
+const { utils } = require('@pins/common');
+
+const config = require('../config');
+const parentLogger = require('./logger');
+
+async function handler(path, method = 'GET', opts = {}, headers = {}) {
+  const correlationId = uuid.v4();
+  const url = `${config.appeals.url}${path}`;
+
+  const logger = parentLogger.child({
+    correlationId,
+    service: 'Appeals Service API',
+  });
+
+  try {
+    logger.debug({ url, method, opts, headers }, 'New call');
+
+    return await utils.promiseTimeout(
+      config.appeals.timeout,
+      Promise.resolve().then(async () => {
+        const apiResponse = await fetch(url, {
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Correlation-ID': correlationId,
+            ...headers,
+          },
+          ...opts,
+        });
+
+        logger.debug('Successfully called');
+
+        const data = await apiResponse.json();
+
+        logger.debug('Successfully parsed to JSON');
+
+        return data;
+      })
+    );
+  } catch (err) {
+    logger.error({ err }, 'Error');
+    throw err;
+  }
+}
+
+exports.getAppeal = async (appealId) => {
+  return handler(`/api/v1/appeals/${appealId}`);
+};

--- a/packages/lpa-questionnaire-web-app/src/middleware/fetch-appeal.js
+++ b/packages/lpa-questionnaire-web-app/src/middleware/fetch-appeal.js
@@ -1,0 +1,27 @@
+const { getAppeal } = require('../lib/appeals-api-wrapper');
+
+/**
+ * Middleware to ensure any appeal data is populated
+ *
+ * @param req
+ * @param res
+ * @param next
+ * @returns {Promise<*>}
+ */
+module.exports = async (req, res, next) => {
+  if (!req.session) {
+    return next();
+  }
+
+  if ((!req.session.appeal || !req.session.appeal.id) && req.params && req.params.id) {
+    try {
+      req.log.debug({ id: req.params.id }, 'Get existing appeal');
+      req.session.appeal = await getAppeal(req.params.id);
+    } catch (err) {
+      req.log.debug({ err }, 'Error retrieving appeal');
+      req.session.appeal = null;
+    }
+  }
+
+  return next();
+};

--- a/packages/lpa-questionnaire-web-app/src/routes/home.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/home.js
@@ -4,6 +4,6 @@ const indexController = require('../controllers');
 const router = express.Router();
 
 /* GET home page. */
-router.get('/', indexController.getIndex);
+router.get('/:id/', indexController.getIndex);
 
 module.exports = router;

--- a/packages/lpa-questionnaire-web-app/src/routes/placeholder.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/placeholder.js
@@ -1,8 +1,9 @@
 const express = require('express');
+const fetchAppealMiddleware = require('../middleware/fetch-appeal');
 const placeholderController = require('../controllers/placeholder');
 
 const router = express.Router();
 
-router.get('/placeholder', placeholderController.getPlaceholder);
+router.get('/:id/placeholder', [fetchAppealMiddleware], placeholderController.getPlaceholder);
 
 module.exports = router;

--- a/packages/lpa-questionnaire-web-app/src/routes/task-list.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/task-list.js
@@ -3,6 +3,6 @@ const taskListController = require('../controllers/task-list');
 
 const router = express.Router();
 
-router.get('/task-list', taskListController.getTaskList);
+router.get('/:id/task-list', taskListController.getTaskList);
 
 module.exports = router;

--- a/packages/lpa-questionnaire-web-app/src/views/components/appeal-details/macro.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/components/appeal-details/macro.njk
@@ -1,0 +1,3 @@
+{% macro appealDetails(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/lpa-questionnaire-web-app/src/views/components/appeal-details/template.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/components/appeal-details/template.njk
@@ -1,0 +1,56 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{%- if params.appeal.number %}
+
+  {% set appealNumber %}
+    <strong class="govuk-tag govuk-tag--turquoise">
+      {{ params.appeal.number }}
+    </strong>
+  {% endset %}
+
+  <aside class="govuk-grid-column-one-third">
+    {{ govukTable({
+      caption: "Appeal details",
+      firstCellIsHeader: true,
+      attributes: {
+        'data-cy': 'appealDetails'
+      },
+      rows: [
+        [
+          {
+            text: "Planning application number"
+          },
+          {
+            html: appealNumber,
+            attributes: {
+              'data-cy': 'planningApplicationNumber'
+            }
+          }
+        ],
+        [
+          {
+            text: "Site address"
+          },
+          {
+            text: params.appeal.address,
+            attributes: {
+              'data-cy': 'planningApplicationAddress'
+            }
+          }
+        ],
+        [
+          {
+            text: "Appellant Name"
+          },
+          {
+            text: params.appeal.appellant,
+            attributes: {
+              'data-cy': 'planningApplicationApellant'
+            }
+          }
+        ]
+      ]
+    }) }}
+  </aside>
+
+{% endif -%}

--- a/packages/lpa-questionnaire-web-app/src/views/placeholder.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/placeholder.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/main.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "components/appeal-details/macro.njk" import appealDetails %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -25,5 +26,13 @@
     </h1>
     <p class="govuk-body-l">Work on this question is not yet complete, this will be replaced when it is completed.</p>
   </div>
+
+  {{
+    appealDetails({
+      appeal: appeal
+    })
+  }}
+
 </div>
+
 {% endblock %}

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/index.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/index.test.js
@@ -1,7 +1,12 @@
 const indexController = require('../../../src/controllers');
 const { mockReq, mockRes } = require('../mocks');
 
-const req = mockReq();
+const req = {
+  ...mockReq(),
+  params: {
+    id: '123-abc',
+  },
+};
 const res = mockRes();
 
 describe('controllers/index', () => {
@@ -9,7 +14,7 @@ describe('controllers/index', () => {
     it('should call the correct template', () => {
       indexController.getIndex(req, res);
 
-      expect(res.redirect).toHaveBeenCalledWith('/task-list');
+      expect(res.redirect).toHaveBeenCalledWith('/123-abc/task-list');
     });
   });
 });

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/placeholder.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/placeholder.test.js
@@ -4,11 +4,16 @@ const { mockReq, mockRes } = require('../mocks');
 
 describe('controllers/placeholder', () => {
   it('Renders the correct view', () => {
-    const req = mockReq();
+    const req = {
+      ...mockReq(),
+      params: {
+        id: '123-abc',
+      },
+    };
     const res = mockRes();
 
     placeholderController.getPlaceholder(req, res);
 
-    expect(res.render).toHaveBeenCalledWith(VIEW.PLACEHOLDER);
+    expect(res.render).toHaveBeenCalledWith(VIEW.PLACEHOLDER, { appeal: null });
   });
 });

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/task-list.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/task-list.test.js
@@ -34,7 +34,12 @@ jest.mock('../../../src/services/task.service', () => ({
 describe('controllers/task-list', () => {
   describe('getTaskList', () => {
     it('All the tasks except check answers should be in not started', () => {
-      const req = mockReq();
+      const req = {
+        ...mockReq(),
+        params: {
+          id: '123-abc',
+        },
+      };
       const res = mockRes();
 
       taskListController.getTaskList(req, res);
@@ -52,7 +57,7 @@ describe('controllers/task-list', () => {
             description: 'Mock Description',
             tasks: [
               {
-                href: '/mock-task-1',
+                href: '/123-abc/mock-task-1',
                 text: 'Mock Task 1',
                 status: 'NOT STARTED',
                 attributes: {
@@ -61,7 +66,7 @@ describe('controllers/task-list', () => {
                 },
               },
               {
-                href: '/mock-task-2',
+                href: '/123-abc/mock-task-2',
                 text: 'Mock Task 2',
                 status: 'NOT STARTED',
                 attributes: {

--- a/packages/lpa-questionnaire-web-app/tests/unit/lib/appeal-sidebar-details.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/lib/appeal-sidebar-details.test.js
@@ -1,0 +1,15 @@
+const appealSidebarDetails = require('../../../src/lib/appeal-sidebar-details');
+const mockAppeal = require('../mockAppeal');
+
+describe('lib/appeals-sidebar-details', () => {
+  it('should return null if no appeal is passed', () => {
+    expect(appealSidebarDetails()).toBeNull();
+  });
+  it('should return formatted details if appeal is passed', () => {
+    expect(appealSidebarDetails(mockAppeal)).toEqual({
+      number: 'ABC/123',
+      address: '999 Letsby Avenue, Sheffield, South Yorkshire, S9 1XY',
+      appellant: 'Bob Smith',
+    });
+  });
+});

--- a/packages/lpa-questionnaire-web-app/tests/unit/lib/appeals-api-wrapper.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/lib/appeals-api-wrapper.test.js
@@ -1,0 +1,47 @@
+jest.mock('uuid');
+
+const fetch = require('node-fetch');
+const { getAppeal } = require('../../../src/lib/appeals-api-wrapper');
+
+const config = require('../../../src/config');
+
+const mockLogger = jest.fn();
+
+jest.mock('../../../src/lib/logger', () => ({
+  child: () => ({
+    debug: mockLogger,
+    error: mockLogger,
+    warn: mockLogger,
+  }),
+}));
+
+config.appeals.url = 'http://fake.url';
+
+describe('lib/appeals-api-wrapper', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+    fetch.doMock();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('getAppeal', () => {
+    it('should call the expected URL', async () => {
+      fetch.mockResponseOnce(JSON.stringify({ shouldBe: 'valid' }));
+      await getAppeal('123');
+      expect(fetch.mock.calls[0][0]).toEqual('http://fake.url/api/v1/appeals/123');
+    });
+
+    it('should return an error if there is a problem contacting then API', async () => {
+      fetch.mockRejectedValueOnce('API is down');
+      try {
+        await getAppeal('123');
+      } catch (e) {
+        expect(e).toEqual('API is down');
+      }
+    });
+  });
+});

--- a/packages/lpa-questionnaire-web-app/tests/unit/middleware/fetch-appeal.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/middleware/fetch-appeal.test.js
@@ -1,0 +1,91 @@
+jest.mock('../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../src/lib/appeals-api-wrapper', () => ({
+  getAppeal: jest.fn(),
+}));
+
+const { mockReq, mockRes } = require('../mocks');
+const fetchAppealMiddleware = require('../../../src/middleware/fetch-appeal');
+const { getAppeal } = require('../../../src/lib/appeals-api-wrapper');
+const config = require('../../../src/config');
+
+config.appeals.url = 'http://fake.url';
+
+describe('middleware/fetch-appeal', () => {
+  [
+    {
+      title: 'call next immediately if no session',
+      given: () => mockReq,
+      expected: (req, res, next) => {
+        expect(getAppeal).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+      },
+    },
+    {
+      title: 'call next immediately if no id in url',
+      given: () => ({
+        ...mockReq(null),
+      }),
+      expected: (req, res, next) => {
+        expect(getAppeal).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+      },
+    },
+    {
+      title: 'if appeal id in session, API is not called',
+      given: () => ({
+        session: {
+          appeal: {
+            id: '123-abc',
+          },
+        },
+      }),
+      expected: (req, res, next) => {
+        expect(getAppeal).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+      },
+    },
+    {
+      title: 'call next if api lookup fails',
+      given: () => {
+        getAppeal.mockRejectedValue('API is down');
+        return {
+          ...mockReq(),
+          params: {
+            id: '123-abc',
+          },
+        };
+      },
+      expected: (req, res, next) => {
+        expect(getAppeal).toHaveBeenCalledWith('123-abc');
+        expect(next).toHaveBeenCalled();
+      },
+    },
+    {
+      title: 'set session.appeal and call next if api call succeeds',
+      given: () => {
+        getAppeal.mockResolvedValue({ good: 'data' });
+
+        return {
+          ...mockReq(),
+          params: {
+            id: '123-abc',
+          },
+        };
+      },
+      expected: (req, res, next) => {
+        expect(getAppeal).toHaveBeenCalledWith('123-abc');
+        expect(next).toHaveBeenCalled();
+        expect(req.session.appeal).toEqual({ good: 'data' });
+      },
+    },
+  ].forEach(({ title, given, expected }) => {
+    it(title, async () => {
+      const next = jest.fn();
+      const req = given();
+
+      await fetchAppealMiddleware(req, mockRes, next);
+
+      expected(req, mockRes, next);
+    });
+  });
+});

--- a/packages/lpa-questionnaire-web-app/tests/unit/mockAppeal.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/mockAppeal.js
@@ -1,0 +1,93 @@
+module.exports = {
+  sectionStates: {
+    aboutYouSection: {
+      yourDetails: 'COMPLETED',
+    },
+    requiredDocumentsSection: {
+      applicationNumber: 'COMPLETED',
+      originalApplication: 'NOT STARTED',
+      decisionLetter: 'NOT STARTED',
+    },
+    yourAppealSection: {
+      appealStatement: 'NOT STARTED',
+      otherDocuments: 'NOT STARTED',
+      otherAppeals: 'NOT STARTED',
+    },
+    appealSiteSection: {
+      siteAccess: 'COMPLETED',
+      siteOwnership: 'COMPLETED',
+      healthAndSafety: 'COMPLETED',
+      siteAddress: 'COMPLETED',
+    },
+  },
+  appealSiteSection: {
+    healthAndSafety: {
+      hasIssues: false,
+      healthAndSafetyIssues: '',
+    },
+    siteAccess: {
+      howIsSiteAccessRestricted: '',
+      canInspectorSeeWholeSiteFromPublicRoad: true,
+    },
+    siteOwnership: {
+      ownsWholeSite: true,
+      haveOtherOwnersBeenTold: null,
+    },
+    siteAddress: {
+      addressLine1: '999 Letsby Avenue',
+      addressLine2: '',
+      town: 'Sheffield',
+      county: 'South Yorkshire',
+      postcode: 'S9 1XY',
+    },
+  },
+  yourAppealSection: {
+    appealStatement: {
+      uploadedFile: {
+        id: 'e4cb9e13-90ad-4c1e-b339-fb0803c2b064',
+        name: 'Birthday-Quiz.pdf',
+        location: 'e8e8124217d256a7cb03a6410f9f3d10',
+        size: 429927,
+      },
+      hasSensitiveInformation: false,
+    },
+    otherDocuments: {
+      uploadedFiles: [],
+    },
+    otherAppeals: {
+      hasOtherAppeal: null,
+      otherAppealRefNumber: '',
+    },
+  },
+  requiredDocumentsSection: {
+    applicationNumber: 'ABC/123',
+    originalApplication: {
+      uploadedFile: {
+        id: '61024954-2dd7-41c2-95ea-0fc2e35fa9bb',
+        name: 'attinghamparkbees.jpg',
+        location: '0d6f62cf1fa8d0797060e5eb6b8dad8f',
+        size: 189549,
+      },
+    },
+    decisionLetter: {
+      uploadedFile: {
+        id: '59c55221-ddaa-4ef8-ba48-c2570b3418e8',
+        name: 'attinghamparkbees.jpg',
+        location: '36d62a0dcb32c3648c8b0f023383464f',
+        size: 189549,
+      },
+    },
+  },
+  aboutYouSection: {
+    yourDetails: {
+      appealingOnBehalfOf: '',
+      email: 'bob@smith.com',
+      name: 'Bob Smith',
+      isOriginalApplicant: true,
+    },
+  },
+  state: 'DRAFT',
+  decisionDate: null,
+  lpaCode: 'E60000068',
+  id: '89aa8504-773c-42be-bb68-029716ad9756',
+};

--- a/packages/lpa-questionnaire-web-app/tests/unit/mocks.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/mocks.js
@@ -5,10 +5,10 @@ const { QUESTIONNAIRE } = require('../../src/lib/empty-questionnaire');
 
 const { empty: emptyQuestionnaire } = QUESTIONNAIRE;
 
-const mockReq = (appeal = emptyQuestionnaire) => ({
+const mockReq = (questionnaire = emptyQuestionnaire) => ({
   log: logger,
   session: {
-    appeal,
+    questionnaire,
   },
 });
 

--- a/packages/lpa-questionnaire-web-app/tests/unit/routes/home.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/routes/home.test.js
@@ -12,6 +12,6 @@ describe('routes/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(get).toHaveBeenCalledWith('/', indexController.getIndex);
+    expect(get).toHaveBeenCalledWith('/:id/', indexController.getIndex);
   });
 });

--- a/packages/lpa-questionnaire-web-app/tests/unit/routes/placeholder.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/routes/placeholder.test.js
@@ -1,5 +1,6 @@
 const { get } = require('./router-mock');
 const placeholderController = require('../../../src/controllers/placeholder');
+const fetchAppealMiddleware = require('../../../src/middleware/fetch-appeal');
 
 describe('routes/placeholder', () => {
   beforeEach(() => {
@@ -12,6 +13,10 @@ describe('routes/placeholder', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(get).toHaveBeenCalledWith('/placeholder', placeholderController.getPlaceholder);
+    expect(get).toHaveBeenCalledWith(
+      '/:id/placeholder',
+      [fetchAppealMiddleware],
+      placeholderController.getPlaceholder
+    );
   });
 });


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-28

## Description of change
- Adding sidebar panel to show appeal details.
- Routing has been changed in application to include passing an appeal ID.
- Wrapper for Appeal API has been added as well as middleware to pull Appeal details.
- Sidebar will not show if no appeal present (invalid ID or API unreachable)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
