### PR TITLE
feat: all filesize limites to 15MB not 50MB

### DIFF
--- a/.github/workflows/e2e-tests-on-PR.yml
+++ b/.github/workflows/e2e-tests-on-PR.yml
@@ -44,15 +44,15 @@ jobs:
           name: results-acp
           path: ${{ env.CYPRESS_REPORTS }}
 
-      - name: Archive videos (on failure) with ACP integration
-        if: ${{ failure() }}
+      - name: Archive videos - with ACP integration
+        if: ${{ always() }}
         uses: actions/upload-artifact@main
         with:
           name: videos-acp
           path: ${{ env.CYPRESS_VIDEOS }}
 
-      - name: Archive screenshots (on failure) with ACP integration
-        if: ${{ failure() }}
+      - name: Archive screenshots - with ACP integration
+        if: ${{ always() }}
         uses: actions/upload-artifact@main
         with:
           name: screenshots-acp
@@ -84,15 +84,15 @@ jobs:
           name: results-lpa
           path: ${{ env.CYPRESS_REPORTS }}
 
-      - name: Archive videos (on failure)
-        if: ${{ failure() }}
+      - name: Archive videos
+        if: ${{ always() }}
         uses: actions/upload-artifact@main
         with:
           name: videos-lpa
           path: ${{ env.CYPRESS_VIDEOS }}
 
-      - name: Archive screenshots (on failure)
-        if: ${{ failure() }}
+      - name: Archive screenshots
+        if: ${{ always() }}
         uses: actions/upload-artifact@main
         with:
           name: screenshots-lpa
@@ -126,15 +126,15 @@ jobs:
           name: results-pins
           path: ${{ env.CYPRESS_REPORTS }}
 
-      - name: Archive videos (on failure) without ACP integration
-        if: ${{ failure() }}
+      - name: Archive videos - without ACP integration
+        if: ${{ always() }}
         uses: actions/upload-artifact@main
         with:
           name: videos-pins
           path: ${{ env.CYPRESS_VIDEOS }}
 
-      - name: Archive screenshots (on failure) without ACP integration
-        if: ${{ failure() }}
+      - name: Archive screenshots - without ACP integration
+        if: ${{ always() }}
         uses: actions/upload-artifact@main
         with:
           name: screenshots-pins

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -30,7 +30,7 @@ documentServiceApi:
       schedule: "*/1 * * * *"
       successfulJobHistoryLimit: 3
     upload:
-      maxSize: 50000000 # 50mb
+      maxSize: 15000000 # 15mb
       maxUploadAttempts: 3
       processQueryLimit: 5
       uploadContainerName: uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     environment:
       BLOB_STORAGE_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://blob-storage:10000/devstoreaccount1;QueueEndpoint=http://blob-storage:10001/devstoreaccount1;
       STORAGE_CONTAINER_NAME: document-service-uploads
-      FILE_MAX_SIZE_IN_BYTES: 50000000
+      FILE_MAX_SIZE_IN_BYTES: 15000000
       FILE_UPLOAD_PATH: /tmp/upload
       MONGODB_AUTO_INDEX: "true"
       MONGODB_URL: mongodb://mongodb:27017/document-service-api
@@ -86,7 +86,7 @@ services:
       APPEALS_SERVICE_API_URL: http://appeals-service-api:3000
       DOCUMENTS_SERVICE_API_URL: http://document-service-api:3000
       FILE_UPLOAD_DEBUG: "false"
-      FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 50000000
+      FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 15000000
       FILE_UPLOAD_USE_TEMP_FILES: "true"
       FILE_UPLOAD_TMP_PATH: "/tmp"
       SESSION_MONGODB_URL: mongodb://mongodb:27017/fwa-sessions
@@ -115,7 +115,7 @@ services:
       APPEALS_SERVICE_API_URL: http://appeals-service-api:3000
       DOCUMENTS_SERVICE_API_URL: http://document-service-api:3000
       FILE_UPLOAD_DEBUG: "false"
-      FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 50000000
+      FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 15000000
       FILE_UPLOAD_USE_TEMP_FILES: "true"
       FILE_UPLOAD_TMP_PATH: "/tmp"
       SESSION_MONGODB_URL: mongodb://mongodb:27017/fwa-sessions

--- a/e2e-tests/create-large-test-files.sh
+++ b/e2e-tests/create-large-test-files.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -z "${FILE_UPLOAD_MAX_FILE_SIZE_BYTES}" ]]; then
-  MAX_SIZE=50000000
+  MAX_SIZE=15000000
 else
   MAX_SIZE=$FILE_UPLOAD_MAX_FILE_SIZE_BYTES
 fi


### PR DESCRIPTION
## Ticket Number
UCD-1366

## Description of change
max file size -> 15MB instead of 50MB

note this requires the local test files to be rebuilt; this happens as a result of make install


## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
