### PR TITLE
fix(nginx-ingress): restart the pods after deployment to pick up configmap changes

### DIFF
--- a/infrastructure/k8s/setup.sh
+++ b/infrastructure/k8s/setup.sh
@@ -81,6 +81,9 @@ install_nginx_ingress() {
     --values "${DIR}/nginx-ingress/${CLUSTER}.yaml" \
     nginx-ingress \
     ingress-nginx/ingress-nginx
+
+  # ConfigMap changes aren't picked up via Helm
+  kubectl rollout restart -n nginx-ingress deployment nginx-ingress-ingress-nginx-controller
 }
 
 install_cert_manager() {


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
UCD-1664

## Description of change
<!-- Please describe the change -->
Apply a rolling restart to the nginx-ingress config after the `helm upgrade` has been run. This is to force the pods to restart in the event of there being a change to a ConfigMap. Helm does not detect if there has been a change to an external ConfigMap, so does not trigger a reload as part of `helm upgrade` - see issues [3868](https://github.com/kubernetes/ingress-nginx/issues/3868) and [5238](https://github.com/kubernetes/ingress-nginx/issues/5238)

By doing a rolling restart, we maintain at least 1 running pod at all times as there are 2 replicas.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [x] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
