### PR TITLE
test: in ACP mode, the service root should redirect to the decision d…

### DIFF
--- a/e2e-tests/cypress/integration-with-acp/handle-unavailable-routes.feature
+++ b/e2e-tests/cypress/integration-with-acp/handle-unavailable-routes.feature
@@ -4,6 +4,10 @@ Feature: Special route handling for ACP integration
   * Eligibility - Decision date expired
   * Eligibility - No decision date
 
+  Scenario: the service root redirects to eligibility: check decision date
+    When a user accesses the root of the service
+    Then the user sees the eligibility: check decision date page
+
   Scenario Outline: (1) Available routes
     Given an appeal is being made
     When an attempt is made to access <page>

--- a/e2e-tests/cypress/integration/common/integration-with-acp.js
+++ b/e2e-tests/cypress/integration/common/integration-with-acp.js
@@ -124,6 +124,14 @@ When('an attempt is made to access {string}', (page) => {
   }
 })
 
+When('a user accesses the root of the service', () => {
+  cy.visit('/');
+});
+
+Then('the user sees the eligibility: check decision date page', () => {
+  cy.confirmNavigationDecisionDatePage();
+});
+
 Then('the {string} is accessed', (page) => {
   switch (page) {
     case 'Eligibility - Decision date':


### PR DESCRIPTION
…ate page

## Ticket Number
UCD-1639

## Description of change
We're about to mess with the redirect rules for the 'real' implementation; we don't want to accidentally break the live behaviour of the ACP side of the site in the case of an unexpected promotion of code->production.

added scenario to the 'redirect' themed feature file to prove that / redirects to the right page; gives us something that will go red in CI if we are breaking ACP-mode functionality..


## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
