### PR TITLE
fix(appeal-data-panel): data would not update when id changed

### DIFF
--- a/packages/lpa-questionnaire-web-app/src/middleware/fetch-appeal.js
+++ b/packages/lpa-questionnaire-web-app/src/middleware/fetch-appeal.js
@@ -9,14 +9,18 @@ const { getAppeal } = require('../lib/appeals-api-wrapper');
  * @returns {Promise<*>}
  */
 module.exports = async (req, res, next) => {
-  if (!req.session) {
+  const appealId = req.params && req.params.id;
+
+  if (!req.session || !appealId) {
     return next();
   }
 
-  if ((!req.session.appeal || !req.session.appeal.id) && req.params && req.params.id) {
+  const { appeal } = req.session;
+
+  if (!appeal || !appeal.id || appeal.id !== appealId) {
     try {
-      req.log.debug({ id: req.params.id }, 'Get existing appeal');
-      req.session.appeal = await getAppeal(req.params.id);
+      req.log.debug({ appealId }, 'Get existing appeal');
+      req.session.appeal = await getAppeal(appealId);
     } catch (err) {
       req.log.debug({ err }, 'Error retrieving appeal');
       req.session.appeal = null;

--- a/packages/lpa-questionnaire-web-app/tests/unit/middleware/fetch-appeal.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/middleware/fetch-appeal.test.js
@@ -31,12 +31,15 @@ describe('middleware/fetch-appeal', () => {
       },
     },
     {
-      title: 'if appeal id in session, API is not called',
+      title: 'if appeal id in session and matches path id, API is not called',
       given: () => ({
         session: {
           appeal: {
             id: '123-abc',
           },
+        },
+        params: {
+          id: '123-abc',
         },
       }),
       expected: (req, res, next) => {
@@ -67,6 +70,45 @@ describe('middleware/fetch-appeal', () => {
 
         return {
           ...mockReq(),
+          params: {
+            id: '123-abc',
+          },
+        };
+      },
+      expected: (req, res, next) => {
+        expect(getAppeal).toHaveBeenCalledWith('123-abc');
+        expect(next).toHaveBeenCalled();
+        expect(req.session.appeal).toEqual({ good: 'data' });
+      },
+    },
+    {
+      title: 'get appeal if appeal object exists but it has no id',
+      given: () => {
+        getAppeal.mockResolvedValue({ good: 'data' });
+
+        return {
+          ...mockReq(),
+          params: {
+            id: '123-abc',
+          },
+        };
+      },
+      expected: (req, res, next) => {
+        expect(getAppeal).toHaveBeenCalledWith('123-abc');
+        expect(next).toHaveBeenCalled();
+        expect(req.session.appeal).toEqual({ good: 'data' });
+      },
+    },
+    {
+      title: 'get appeal if appeal id does not match path id',
+      given: () => {
+        getAppeal.mockResolvedValue({ good: 'data' });
+
+        return {
+          ...mockReq(),
+          appeal: {
+            id: '456-def',
+          },
           params: {
             id: '123-abc',
           },


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-71

## Description of change
Fixes an issue where if an appeal was retrieved, but the ID in the path was changed, the system would not fetch the new ID. This has been added, the logic made a little clearer and additional test cases created.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
