### PR TITLE
feat(lpa-questionnaire): add backlink to session for back button usage

### DIFF
--- a/packages/lpa-questionnaire-web-app/src/controllers/other-appeals.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/other-appeals.js
@@ -23,6 +23,7 @@ exports.getOtherAppeals = (req, res) => {
 
   res.render(VIEW.OTHER_APPEALS, {
     appeal: getAppealSideBarDetails(req.session.appeal),
+    backLink: req.session.backLink,
     values,
   });
 };
@@ -42,6 +43,7 @@ exports.postOtherAppeals = async (req, res) => {
   if (Object.keys(errors).length > 0) {
     res.render(VIEW.OTHER_APPEALS, {
       appeal: getAppealSideBarDetails(req.session.appeal),
+      backLink: req.session.backLink,
       errors,
       errorSummary,
       values,
@@ -66,6 +68,7 @@ exports.postOtherAppeals = async (req, res) => {
 
     res.render(VIEW.OTHER_APPEALS, {
       appeal: getAppealSideBarDetails(req.session.appeal),
+      backLink: req.session.backLink,
       errors,
       errorSummary: [{ text: e.toString() }],
       values,
@@ -74,5 +77,5 @@ exports.postOtherAppeals = async (req, res) => {
     return;
   }
 
-  res.redirect(`/${req.params.id}/${VIEW.TASK_LIST}`);
+  res.redirect(req.session.backLink);
 };

--- a/packages/lpa-questionnaire-web-app/src/controllers/placeholder.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/placeholder.js
@@ -4,5 +4,6 @@ const getAppealSideBarDetails = require('../lib/appeal-sidebar-details');
 exports.getPlaceholder = (req, res) => {
   res.render(VIEW.PLACEHOLDER, {
     appeal: getAppealSideBarDetails(req.session.appeal),
+    backLink: req.session.backLink,
   });
 };

--- a/packages/lpa-questionnaire-web-app/src/controllers/task-list.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/task-list.js
@@ -39,6 +39,9 @@ exports.getTaskList = (req, res) => {
   const sections = buildTaskLists(appealReply, req.params.id);
   const applicationStatus = 'Application incomplete';
 
+  // Set backLink property in session
+  req.session.backLink = `/${req.params.id}/${VIEW.TASK_LIST}`;
+
   res.render(VIEW.TASK_LIST, {
     applicationStatus,
     sections,

--- a/packages/lpa-questionnaire-web-app/src/views/placeholder.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/placeholder.njk
@@ -6,7 +6,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: "javascript:history.back()",
+    href: backLink,
     attributes: {
       'data-cy': 'back'
     }

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/other-appeals.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/other-appeals.test.js
@@ -26,10 +26,13 @@ describe('controllers/other-appeals', () => {
 
   describe('getOtherAppeals', () => {
     it('should call the correct template', () => {
+      req.session.backLink = `/mock-id/${VIEW.TASK_LIST}`;
+
       otherAppealsController.getOtherAppeals(req, res);
 
       expect(res.render).toHaveBeenCalledWith(VIEW.OTHER_APPEALS, {
         appeal: null,
+        backLink: `/mock-id/${VIEW.TASK_LIST}`,
         values: {
           'adjacent-appeals': null,
           'appeal-reference-numbers': '',
@@ -98,6 +101,7 @@ describe('controllers/other-appeals', () => {
           'adjacent-appeals': 'no',
         },
       };
+      mockRequest.session.backLink = `/mock-id/${VIEW.TASK_LIST}`;
 
       await otherAppealsController.postOtherAppeals(mockRequest, res);
 
@@ -122,6 +126,7 @@ describe('controllers/other-appeals', () => {
           'appeal-reference-numbers': 'some-reference',
         },
       };
+      mockRequest.session.backLink = `/mock-id/${VIEW.TASK_LIST}`;
 
       await otherAppealsController.postOtherAppeals(mockRequest, res);
 

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/placeholder.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/placeholder.test.js
@@ -9,11 +9,17 @@ describe('controllers/placeholder', () => {
       params: {
         id: '123-abc',
       },
+      session: {
+        backLink: `/mock-id/${VIEW.TASK_LIST}`,
+      },
     };
     const res = mockRes();
 
     placeholderController.getPlaceholder(req, res);
 
-    expect(res.render).toHaveBeenCalledWith(VIEW.PLACEHOLDER, { appeal: null });
+    expect(res.render).toHaveBeenCalledWith(VIEW.PLACEHOLDER, {
+      appeal: null,
+      backLink: `/mock-id/${VIEW.TASK_LIST}`,
+    });
   });
 });

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/task-list.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/task-list.test.js
@@ -34,12 +34,7 @@ jest.mock('../../../src/services/task.service', () => ({
 describe('controllers/task-list', () => {
   describe('getTaskList', () => {
     it('All the tasks except check answers should be in not started', () => {
-      const req = {
-        ...mockReq(),
-        params: {
-          id: '123-abc',
-        },
-      };
+      const req = mockReq();
       const res = mockRes();
 
       taskListController.getTaskList(req, res);
@@ -57,7 +52,7 @@ describe('controllers/task-list', () => {
             description: 'Mock Description',
             tasks: [
               {
-                href: '/123-abc/mock-task-1',
+                href: '/mock-id/mock-task-1',
                 text: 'Mock Task 1',
                 status: 'NOT STARTED',
                 attributes: {
@@ -66,7 +61,7 @@ describe('controllers/task-list', () => {
                 },
               },
               {
-                href: '/123-abc/mock-task-2',
+                href: '/mock-id/mock-task-2',
                 text: 'Mock Task 2',
                 status: 'NOT STARTED',
                 attributes: {


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-83

## Description of change
Added backlink to session to be passed to templates later for back button functionality.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
