### PR TITLE
chore(appeals-reply-service): add reply service url to lpq questionnaire config

### DIFF
--- a/charts/app/templates/lpaQuestionnaireWebApp.yaml
+++ b/charts/app/templates/lpaQuestionnaireWebApp.yaml
@@ -49,6 +49,8 @@ spec:
               path: /health
               port: {{.Values.lpaQuestionnaireWebApp.service.name }}
           env:
+            - name: APPEAL_REPLY_SERVICE_API_URL
+              value: "http://{{ include "app.fullname" . }}:{{ .Values.appealReplyServiceApi.service.port }}"
             - name: APPEALS_SERVICE_API_URL
               value: "http://{{ include "app.fullname" . }}:{{ .Values.appealsServiceApi.service.port }}"
             - name: DOCUMENTS_SERVICE_API_URL
@@ -63,6 +65,8 @@ spec:
               value: {{ .Values.lpaQuestionnaireWebApp.config.upload.uploadDir | quote }}
             - name: FILE_UPLOAD_USE_TEMP_FILES
               value: {{ .Values.lpaQuestionnaireWebApp.config.upload.useTmpFiles | quote }}
+            - name: LOGGER_LEVEL
+              value: {{ .Values.lpaQuestionnaireWebApp.config.logLevel }}
             - name: PORT
               value: {{ .Values.lpaQuestionnaireWebApp.config.port | quote }}
             - name: SESSION_MONGODB_DB_NAME

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -83,6 +83,7 @@ lpaQuestionnaireWebApp:
   config:
     port: 3000
     googleAnalyticsId: ""
+    logLevel: trace
     upload:
       debug: true
       uploadDir: /upload-dir


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1125

## Description of change
<!-- Please describe the change -->
Had missed out the Reply Service config URL from the questionnaire config object

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
