### PR TITLE
feat(e2e-tests): adds FF for Creation of submission information file

### DIFF
--- a/e2e-tests/cypress/integration/appeal-submission-creation-of-submission-information-file.feature
+++ b/e2e-tests/cypress/integration/appeal-submission-creation-of-submission-information-file.feature
@@ -1,0 +1,12 @@
+@wip
+Feature: Appeal Submission - Creation of submission information file
+
+  As a Planning Inspectorate case worker
+  I want a human readable file containing the appellant’s appeal submission information, at point of submission
+  So that I have all the information collected during the appeal submission that was not explicitly passed to Horizon
+
+  @as-101
+  Scenario: Summary of submission
+    Given a prospective appellant has provided valid appeal information
+    When the appeal is submitted
+    Then a submission information file is created


### PR DESCRIPTION
This has already been approved - but has been lost in rebase
https://github.com/foundry4/appeal-planning-decision/pull/529