### PR TITLE
fix(infrastructure): change default vpn sku to VpnGw1AZ

### DIFF
--- a/infrastructure/environments/README.md
+++ b/infrastructure/environments/README.md
@@ -25,7 +25,7 @@ No requirements.
 | documents\_soft\_delete\_retention | Number of days to allow for data recovery | `number` | `30` | no |
 | horizon\_enabled | Enable the connection to the Horizon instance over a virtual network gateway | `bool` | `false` | no |
 | horizon\_gateway\_ip\_secret | Public IP address of the Horizon VPN gateway | `string` | `"horizon-gateway-ip"` | no |
-| horizon\_gateway\_sku | SKU of the Horizon gateway | `string` | `"VpnGw1"` | no |
+| horizon\_gateway\_sku | SKU of the Horizon gateway | `string` | `"VpnGw1AZ"` | no |
 | horizon\_gateway\_subnets\_secret | CSV of subnets to use for the Horizon VPN gateway | `string` | `null` | no |
 | horizon\_shared\_key\_secret | Name of the Horizon shared key in the PINS key vault | `string` | `null` | no |
 | k8s\_availability\_zones | Zones to run the node pools in | `list(string)` | `null` | no |

--- a/infrastructure/environments/variables.tf
+++ b/infrastructure/environments/variables.tf
@@ -53,7 +53,7 @@ variable "horizon_enabled" {
 variable "horizon_gateway_sku" {
   description = "SKU of the Horizon gateway"
   type = string
-  default = "VpnGw1"
+  default = "VpnGw1AZ"
 }
 
 variable "horizon_gateway_ip_secret" {


### PR DESCRIPTION
This is SKU doesn't work with a VMScaleSet deployment - looks like to do with multiple nodes in the K8S cluster. Switching to the Availability Zone version of the SKU fixes that.

## Ticket Number
<!-- Add the number from the Jira board -->
UCD-831

## Description of change
<!-- Please describe the change -->

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
